### PR TITLE
IDE-893

### DIFF
--- a/build/releng/com.liferay.ide-repository/bundle/bundle.properties
+++ b/build/releng/com.liferay.ide-repository/bundle/bundle.properties
@@ -35,12 +35,12 @@ eclipse.macosx64.zip.name=eclipse-jee-juno-SR2-macosx-cocoa-x86_64.tar.gz
 eclipse.macosx64.tar.name=eclipse-jee-juno-SR2-macosx-cocoa-x86_64.tar
 eclipse.macosx64.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/juno/SR2/eclipse-jee-juno-SR2-macosx-cocoa-x86_64.tar.gz
 
-output.win32.zip.name=eclipse_Liferay_IDE_${ideVersion}-win32.zip
+output.win32.zip.name=eclipse_Liferay_IDE_${ideVersion}-windows.zip
 output.linux.tar.name=eclipse_Liferay_IDE_${ideVersion}-linux.tar
 output.linux.gz.name=eclipse_Liferay_IDE_${ideVersion}-linux.tar.gz
 output.macosx.tar.name=eclipse_Liferay_IDE_${ideVersion}-macosx.tar
 output.macosx.gz.name=eclipse_Liferay_IDE_${ideVersion}-macosx.tar.gz
-output.win64.zip.name=eclipse_Liferay_IDE_${ideVersion}-win32-x86_64.zip
+output.win64.zip.name=eclipse_Liferay_IDE_${ideVersion}-windows-x86_64.zip
 output.linux64.tar.name=eclipse_Liferay_IDE_${ideVersion}-linux-x86_64.tar
 output.linux64.gz.name=eclipse_Liferay_IDE_${ideVersion}-linux-x86_64.tar.gz
 output.macosx64.tar.name=eclipse_Liferay_IDE_${ideVersion}-macosx-x86_64.tar


### PR DESCRIPTION
changed the bundle name from eclipse_Liferay_IDE...win32-x86_64.zip to
    eclipse_Liferay_IDE...windows-x86_64.zip and
    eclipse_Liferay_IDE...win32.zip to eclipse_Liferay_IDE...windows.zip
