### PR TITLE
IDE-854

### DIFF
--- a/tools/plugins/com.liferay.ide.service.core/src/com/liferay/ide/service/core/model/Column.java
+++ b/tools/plugins/com.liferay.ide.service.core/src/com/liferay/ide/service/core/model/Column.java
@@ -16,6 +16,7 @@
 package com.liferay.ide.service.core.model;
 
 import com.liferay.ide.service.core.model.internal.ColumnImageService;
+import com.liferay.ide.service.core.model.internal.TypePossibleValuesService;
 
 import org.eclipse.sapphire.Since;
 import org.eclipse.sapphire.modeling.IModelElement;
@@ -34,6 +35,7 @@ import org.eclipse.sapphire.modeling.xml.annotations.XmlBinding;
 
 /**
  * @author Gregory Amerson
+ * @author Cindy Li
  */
 @GenerateImpl
 @Service( impl = ColumnImageService.class )
@@ -68,11 +70,7 @@ public interface Column extends IModelElement
     @Label( standard = "type" )
     @XmlBinding( path = "@type" )
     @Required
-    @PossibleValues
-    (
-        values = { "String", "long", "boolean", "int", "double", "Date", "Collection" },
-        invalidValueMessage = "{0} is not a valid type."
-    )
+    @Service( impl = TypePossibleValuesService.class )
     ValueProperty PROP_TYPE = new ValueProperty( TYPE, "Type" ); //$NON-NLS-1$
 
     Value<String> getType();

--- a/tools/plugins/com.liferay.ide.service.core/src/com/liferay/ide/service/core/model/internal/TypePossibleValuesService.java
+++ b/tools/plugins/com.liferay.ide.service.core/src/com/liferay/ide/service/core/model/internal/TypePossibleValuesService.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ *******************************************************************************/
+
+package com.liferay.ide.service.core.model.internal;
+
+import com.liferay.ide.service.core.model.ServiceBuilder6xx;
+
+import java.util.SortedSet;
+
+import org.eclipse.sapphire.Version;
+import org.eclipse.sapphire.services.PossibleValuesService;
+
+/**
+ * @author Cindy Li
+ */
+public class TypePossibleValuesService extends PossibleValuesService
+{
+    private static final String[] DEFAULT_TYPES = { "String", "long", "boolean", "int", "double", "Date", "Collection" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$
+
+    @Override
+    protected void fillPossibleValues( SortedSet<String> values )
+    {
+        for( int i = 0; i < DEFAULT_TYPES.length; i++ )
+        {
+            values.add( DEFAULT_TYPES[i] );
+        }
+
+        ServiceBuilder6xx serviceBuilder = context( ServiceBuilder6xx.class );
+
+        if( serviceBuilder.getVersion().getContent( true ).compareTo( new Version( "6.2" ) ) >= 0 ) //$NON-NLS-1$
+        {
+            values.add( "Blob" ); //$NON-NLS-1$
+        }
+    }
+
+}


### PR DESCRIPTION
Add a valid type "Blob" for Column in Service Builder editor when using portal version 6.2 or greater by customizing a PossibleValuesService class for Column model's Type property instead of hard coded.
