### PR TITLE
IDE-965

### DIFF
--- a/tools/plugins/com.liferay.ide.layouttpl.core/src/com/liferay/ide/layouttpl/core/model/PortletRowLayoutElement.java
+++ b/tools/plugins/com.liferay.ide.layouttpl.core/src/com/liferay/ide/layouttpl/core/model/PortletRowLayoutElement.java
@@ -138,10 +138,17 @@ public class PortletRowLayoutElement extends ModelElement implements PropertyCha
                 if( i == 0 && cols.size() > 1 )
                 {
                     col.setFirst( true );
+                    col.setLast( false );
                 }
                 else if( cols.size() > 1 && i == ( cols.size() - 1 ) )
                 {
                     col.setLast( true );
+                    col.setFirst( false );
+                }
+                else
+                {
+                    col.setFirst( false );
+                    col.setLast( false );
                 }
             }
         }


### PR DESCRIPTION
Clear first/last quality from the old first/last column
to fix the redundant first/last marks in source editor
when keep adding new columns to the first/last place.
