### PR TITLE
IDE-1039

### DIFF
--- a/tools/plugins/com.liferay.ide.project.ui/plugin.xml
+++ b/tools/plugins/com.liferay.ide.project.ui/plugin.xml
@@ -242,11 +242,11 @@
 						</or>
 					</not>
 					<and>
-					<adapt type="org.eclipse.core.resources.IProject">
-						<test forcePluginActivation="true"
-						property="com.liferay.ide.project.ui.isSDKFolderProject"
-						value="true" />	
-					</adapt>
+						<adapt type="org.eclipse.core.resources.IProject">
+							<test forcePluginActivation="true"
+								property="com.liferay.ide.project.ui.isSDKFolderProject"
+								value="true" />	
+						</adapt>
 					</and>
 				</and>
 			 </adapt>


### PR DESCRIPTION
Fixed the covert to liferay project menu enabled when right click on the non-SDK-folder project and looking into the Liferay menu.
