### PR TITLE
IDE-1186

### DIFF
--- a/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/ui/editor/PortletXmlEditor.sdef
+++ b/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/ui/editor/PortletXmlEditor.sdef
@@ -63,7 +63,7 @@
                     <collapsible>false</collapsible>
                     <scroll-vertically>true</scroll-vertically>
                     <scroll-horizontally>true</scroll-horizontally>
-                    <indent>true</indent>
+                    <indent>false</indent>
                 </section>
                 <node>
                     <label>Portlets</label>
@@ -537,7 +537,7 @@
                     </property-editor>
                 </content>
                 <collapsible>false</collapsible>
-                <indent>true</indent>
+                <indent>false</indent>
             </section>
             <label>${( (empty Name AND empty NamespaceURI AND empty LocalPart )
                 ||


### PR DESCRIPTION
Fixed the sapphire portlet.xml editor open error which caused by the
TableWrapData casting from GridData.
