### PR TITLE
IDE-1018

### DIFF
--- a/common/plugins/com.liferay.ide.debug.core/src/com/liferay/ide/debug/core/fm/FMDebugTarget.java
+++ b/common/plugins/com.liferay.ide.debug.core/src/com/liferay/ide/debug/core/fm/FMDebugTarget.java
@@ -335,13 +335,13 @@ public class FMDebugTarget extends FMDebugElement implements IDebugTarget, IDebu
      */
     public void breakpointAdded( IBreakpoint breakpoint )
     {
-        if( supportsBreakpoint( breakpoint ) && ! this.launch.isTerminated() )
+        if( supportsBreakpoint( breakpoint ) && !this.launch.isTerminated() )
         {
             try
             {
                 Debugger debugger = getDebuggerClient();
 
-                if( debugger !=null && breakpoint.isEnabled() )
+                if( debugger != null && breakpoint.isEnabled() )
                 {
                     addRemoteBreakpoints( debugger, new IBreakpoint[] { breakpoint } );
                 }


### PR DESCRIPTION
Fixed the add and remove FM debugger breakpoint when server is not fully
started, also fixed the resume error when server is shutdown.
