### PR TITLE
IDE-1406 Make user can only use valid class name

### DIFF
--- a/tools/plugins/com.liferay.ide.hook.ui/src/com/liferay/ide/hook/ui/wizard/NewEventActionClassDialog.java
+++ b/tools/plugins/com.liferay.ide.hook.ui/src/com/liferay/ide/hook/ui/wizard/NewEventActionClassDialog.java
@@ -323,15 +323,16 @@ public class NewEventActionClassDialog extends Dialog
         }
 
         boolean isPackageNameAndClassNameValid =
-            ( ( packageNameStatus != IStatus.ERROR ) && ( classNameStatus != IStatus.ERROR ) );
+            ( packageNameStatus != IStatus.ERROR && classNameStatus != IStatus.ERROR && classNameStatus != IStatus.WARNING );
 
         this.getButton( IDialogConstants.OK_ID ).setEnabled( isPackageNameAndClassNameValid );
 
-        if( classNameStatus == IStatus.ERROR && packageNameStatus == IStatus.ERROR )
+        if( ( ( classNameStatus == IStatus.ERROR ) || ( classNameStatus == IStatus.WARNING ) ) &&
+            packageNameStatus == IStatus.ERROR )
         {
             this.errorMessageLabel.setText( "Invalid package and class name" );
         }
-        else if( classNameStatus == IStatus.ERROR )
+        else if( ( classNameStatus == IStatus.ERROR ) || ( classNameStatus == IStatus.WARNING ) )
         {
             this.errorMessageLabel.setText( "Invalid class name" );
         }


### PR DESCRIPTION
1.make sure user can only type valid class name and it won't have any warning and error
message for its validation.
