### PR TITLE
IDE-1524 fixed the Chinese characters encodeing bugs in SDK path on Windows

### DIFF
--- a/tools/plugins/com.liferay.ide.sdk.core/src/com/liferay/ide/sdk/core/SDKManager.java
+++ b/tools/plugins/com.liferay.ide.sdk.core/src/com/liferay/ide/sdk/core/SDKManager.java
@@ -239,7 +239,7 @@ public final class SDKManager
             {
                 XMLMemento root =
                     XMLMemento.createReadRoot( new InputStreamReader( new ByteArrayInputStream(
-                        sdksXmlString.getBytes( "UTF-8" ) ) ) ); //$NON-NLS-1$
+                        sdksXmlString.getBytes( "UTF-8" ) ), "UTF-8" ) ); //$NON-NLS-1$
 
                 String defaultSDKName = root.getString( "default" ); //$NON-NLS-1$
 


### PR DESCRIPTION
Has been tested on the three OS
