### PR TITLE
IDE-1543 removed the extensions of liferay-plugin-properties content-type

### DIFF
--- a/common/plugins/com.liferay.ide.core/OSGI-INF/l10n/bundle.properties
+++ b/common/plugins/com.liferay.ide.core/OSGI-INF/l10n/bundle.properties
@@ -5,4 +5,3 @@ project.adapters.ext.point.name = Liferay Project Adapters
 project.providers.ext.point.name = Liferay Project Providers
 liferay.language.properties.file.name = Liferay Language Properties File
 liferay.language.properties.problem.name = Liferay Language Properties Problems
-liferay.portal.properties.file.name = Liferay Portal Properties File

--- a/common/plugins/com.liferay.ide.core/plugin.xml
+++ b/common/plugins/com.liferay.ide.core/plugin.xml
@@ -26,14 +26,6 @@
                class="com.liferay.ide.core.describer.LiferayLanguagePropertiesFileDescriber">
          </describer>
       </content-type>
-      <content-type
-            base-type="org.eclipse.jdt.core.javaProperties"
-            file-extensions="properties"
-            file-names="portal.properties"
-            id="portalpropertiesfile"
-            name="%liferay.portal.properties.file.name"
-            priority="high">
-      </content-type>
    </extension>
    <extension
          id="LiferayLanguagePropertiesMarker"

--- a/tools/plugins/com.liferay.ide.portlet.core/plugin.xml
+++ b/tools/plugins/com.liferay.ide.portlet.core/plugin.xml
@@ -43,11 +43,11 @@
             priority="high">
       </content-type>
       <content-type
-            file-extensions="properties"
+            base-type="org.eclipse.jdt.core.javaProperties"
             file-names="liferay-plugin-package.properties"
             id="liferaypluginpackageproperties"
             name="%liferay.plugin.package.descriptor.name"
-            priority="normal">
+            priority="high">
       </content-type>
    </extension>
    <extension


### PR DESCRIPTION
a better way to which makes more sense and avoids the protential issues
