### PR TITLE
IDE-1703 add quick fix to support for all the validation types and change var "validationKey" to make more sense

### DIFF
--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/BaseValidator.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/BaseValidator.java
@@ -220,7 +220,7 @@ public abstract class BaseValidator extends AbstractValidator
 
     protected void checkDocrootElement(
         IDOMDocument document, String element, IProject project, String preferenceNodeQualifier,
-        IScopeContext[] preferenceScopes, String validationKey, String messageKey, List<Map<String, Object>> problems )
+        IScopeContext[] preferenceScopes, String liferayPluginValidationType, String messageKey, List<Map<String, Object>> problems )
     {
         NodeList elements = document.getElementsByTagName( element );
 
@@ -230,7 +230,7 @@ public abstract class BaseValidator extends AbstractValidator
 
             Map<String, Object> problem =
                 checkDocrootResource(
-                    item, project, preferenceNodeQualifier, preferenceScopes, validationKey, messageKey );
+                    item, project, preferenceNodeQualifier, preferenceScopes, liferayPluginValidationType, messageKey );
 
             if( problem != null )
             {

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/ValidationPreferences.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/ValidationPreferences.java
@@ -161,9 +161,9 @@ public class ValidationPreferences
         preferenceKeys.add( LIFERAY_JSP_TYPE_HIERARCHY_INCORRECT );
     }
 
-    public static boolean containsKey( String validationKey )
+    public static boolean containsKey( String liferayPluginValidationType )
     {
-        return preferenceKeys.contains( validationKey );
+        return preferenceKeys.contains( liferayPluginValidationType );
     }
 
     public static String getValidationPreferenceKey( String descriptorFileName, ValidationType type )
@@ -185,14 +185,14 @@ public class ValidationPreferences
     }
 
     // Levels: IGNORE: -1, ERROR: 1, WARNNING: 2
-    public static void setInstanceScopeValidationLevel( String validationKey, int validationLevel )
+    public static void setInstanceScopeValidationLevel( String liferayPluginValidationType, int validationLevel )
     {
-        if( preferenceKeys.contains( validationKey ) &&
+        if( preferenceKeys.contains( liferayPluginValidationType ) &&
             ( validationLevel == -1 || validationLevel == 1 || validationLevel == 2 ) )
         {
             final IEclipsePreferences node = InstanceScope.INSTANCE.getNode( ProjectCore.PLUGIN_ID );
 
-            node.putInt( validationKey, validationLevel );
+            node.putInt( liferayPluginValidationType, validationLevel );
 
             try
             {
@@ -206,15 +206,15 @@ public class ValidationPreferences
 
     }
 
-    public static void setProjectScopeValidationLevel( IProject project, String validationKey, int validationLevel )
+    public static void setProjectScopeValidationLevel( IProject project, String liferayPluginValidationType, int validationLevel )
     {
         final IEclipsePreferences node = new ProjectScope( project ).getNode( ProjectCore.PLUGIN_ID );
 
-        if( preferenceKeys.contains( validationKey ) &&
+        if( preferenceKeys.contains( liferayPluginValidationType ) &&
             ( validationLevel == -1 || validationLevel == 1 || validationLevel == 2 ) )
         {
             node.putBoolean( ProjectCore.USE_PROJECT_SETTINGS, true );
-            node.putInt( validationKey, validationLevel );
+            node.putInt( liferayPluginValidationType, validationLevel );
             try
             {
                 node.flush();

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/JSPMarkerResolutionGenerator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/JSPMarkerResolutionGenerator.java
@@ -202,7 +202,7 @@ public class JSPMarkerResolutionGenerator implements IMarkerResolutionGenerator2
                 return true;
             }
 
-            final String valKey = marker.getAttribute( XMLSearchConstants.VALIDATION_KEY, null );
+            final String valKey = marker.getAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE, null );
 
             if( valKey != null && ValidationPreferences.containsKey( valKey ) )
             {

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/XMLSearchConstants.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/XMLSearchConstants.java
@@ -32,5 +32,6 @@ public interface XMLSearchConstants
     String RESOURCE_BUNDLE_QUERY_ID = "portlet.language.properties.querySpecification";
     String SERVICE_BUILDER_CONTENT_TYPE = "com.liferay.ide.service.core.servicebuildercontent";
     String TEXT_CONTENT = "textContent";
-    String VALIDATION_KEY = "validationKey";
+    String LIFERAY_PLUGIN_VALIDATION_TYPE_OLD = "validationKey";
+    String LIFERAY_PLUGIN_VALIDATION_TYPE = "liferayPluginValidationType";
 }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/markerResolutions/DecreaseInstanceScopeXmlValidationLevel.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/markerResolutions/DecreaseInstanceScopeXmlValidationLevel.java
@@ -70,16 +70,21 @@ public class DecreaseInstanceScopeXmlValidationLevel implements IMarkerResolutio
         final IEclipsePreferences node =
             new ProjectScope( marker.getResource().getProject() ).getNode( ProjectCore.PLUGIN_ID );
 
-        final String validationKey = marker.getAttribute( XMLSearchConstants.VALIDATION_KEY, null );
-        if( validationKey != null )
+        String liferayPluginValidationType = marker.getAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE, null );
+        
+        if( liferayPluginValidationType == null )
+        {
+            liferayPluginValidationType = marker.getAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE_OLD, null );
+        }
+        if( liferayPluginValidationType != null )
         {
             if( node.getBoolean( ProjectCore.USE_PROJECT_SETTINGS, false ) )
             {
                 ValidationPreferences.setProjectScopeValidationLevel(
-                    marker.getResource().getProject(), validationKey, -1 );
+                    marker.getResource().getProject(), liferayPluginValidationType, -1 );
             }
 
-            ValidationPreferences.setInstanceScopeValidationLevel( validationKey, -1 );
+            ValidationPreferences.setInstanceScopeValidationLevel( liferayPluginValidationType, -1 );
             ComponentUtil.validateFile( (IFile) marker.getResource(), new NullProgressMonitor() );
         }
     }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/markerResolutions/DecreaseProjectScopeXmlValidationLevel.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/markerResolutions/DecreaseProjectScopeXmlValidationLevel.java
@@ -63,11 +63,16 @@ public class DecreaseProjectScopeXmlValidationLevel implements IMarkerResolution
     @Override
     public void run( IMarker marker )
     {
-        final String validationKey = marker.getAttribute( XMLSearchConstants.VALIDATION_KEY, null );
-
-        if( validationKey != null )
+        String liferayPluginValidationType = marker.getAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE, null );
+        
+        if( liferayPluginValidationType == null )
         {
-            ValidationPreferences.setProjectScopeValidationLevel( marker.getResource().getProject(), validationKey, -1 );
+            liferayPluginValidationType = marker.getAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE_OLD, null );
+        }
+
+        if( liferayPluginValidationType != null )
+        {
+            ValidationPreferences.setProjectScopeValidationLevel( marker.getResource().getProject(), liferayPluginValidationType, -1 );
             ComponentUtil.validateFile( (IFile) marker.getResource(), new NullProgressMonitor() );
         }
     }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/markerResolutions/XmlValidationMarkerResolutionGenerator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/markerResolutions/XmlValidationMarkerResolutionGenerator.java
@@ -14,9 +14,9 @@
 
 package com.liferay.ide.xml.search.ui.markerResolutions;
 
+import com.liferay.ide.project.core.ValidationPreferences;
 import com.liferay.ide.xml.search.ui.LiferayXMLSearchUI;
-import com.liferay.ide.xml.search.ui.validators.LiferayBaseValidator;
-
+import com.liferay.ide.xml.search.ui.XMLSearchConstants;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +40,13 @@ public class XmlValidationMarkerResolutionGenerator implements IMarkerResolution
 
         try
         {
-            if( marker.getAttribute( LiferayBaseValidator.MARKER_QUERY_ID ) != null )
+            String liferayPluginValidationType=marker.getAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE ).toString();
+            
+            if( liferayPluginValidationType == null )
+            {
+                liferayPluginValidationType=marker.getAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE_OLD ).toString();
+            }
+            if( liferayPluginValidationType != null && ValidationPreferences.containsKey( liferayPluginValidationType ) )
             {
                 retval.add( new DecreaseProjectScopeXmlValidationLevel() );
                 retval.add( new DecreaseInstanceScopeXmlValidationLevel() );

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayBaseValidator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayBaseValidator.java
@@ -203,13 +203,13 @@ public class LiferayBaseValidator implements IXMLReferenceValidator, IXMLReferen
     }
 
     protected void addMessage( IDOMNode node, IFile file, IValidator validator, IReporter reporter, boolean batchMode,
-                               String messageText, int severity, String validationKey )
+                               String messageText, int severity, String liferayPluginValidationType )
     {
-        addMessage( node, file, validator, reporter, batchMode, messageText, severity, validationKey, null );
+        addMessage( node, file, validator, reporter, batchMode, messageText, severity, liferayPluginValidationType, null );
     }
 
     protected void addMessage( IDOMNode node, IFile file, IValidator validator, IReporter reporter, boolean batchMode,
-                               String messageText, int severity, String validationKey, String querySpecificationId )
+                               String messageText, int severity, String liferayPluginValidationType, String querySpecificationId )
     {
         int startOffset = getStartOffset( node );
         int length = node.getEndOffset() - startOffset;
@@ -223,7 +223,7 @@ public class LiferayBaseValidator implements IXMLReferenceValidator, IXMLReferen
             {
                 message.setTargetObject( file );
                 message.setAttribute( MARKER_QUERY_ID, querySpecificationId );
-                message.setAttribute( XMLSearchConstants.VALIDATION_KEY, validationKey );
+                message.setAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE, liferayPluginValidationType );
                 reporter.addMessage( validator, message );
             }
         }
@@ -371,11 +371,11 @@ public class LiferayBaseValidator implements IXMLReferenceValidator, IXMLReferen
 
     protected int getServerity( ValidationType validationType, IFile file )
     {
-        final String validationKey = getValidationKey( validationType, file );
+        final String liferayPluginValidationType = getLiferayPluginValidationType( validationType, file );
 
         // get severity from users' settings
         return Platform.getPreferencesService().getInt(
-            PREFERENCE_NODE_QUALIFIER, validationKey, IMessage.NORMAL_SEVERITY, getScopeContexts( file.getProject() ) );
+            PREFERENCE_NODE_QUALIFIER, liferayPluginValidationType, IMessage.NORMAL_SEVERITY, getScopeContexts( file.getProject() ) );
     }
 
     protected int getStartOffset( IDOMNode node )
@@ -391,7 +391,7 @@ public class LiferayBaseValidator implements IXMLReferenceValidator, IXMLReferen
         return node.getStartOffset();
     }
 
-    protected String getValidationKey( ValidationType validationType, IFile file )
+    protected String getLiferayPluginValidationType( ValidationType validationType, IFile file )
     {
         return ValidationPreferences.getValidationPreferenceKey( file.getName(), validationType );
     }
@@ -521,13 +521,13 @@ public class LiferayBaseValidator implements IXMLReferenceValidator, IXMLReferen
             {
                 ValidationType validationType = getValidationType( referenceTo, nbElements );
                 int severity = getServerity( validationType, file );
-                final String validationKey = getValidationKey( validationType, file );
+                final String liferayPluginValidationType = getLiferayPluginValidationType( validationType, file );
 
                 if( severity != ValidationMessage.IGNORE )
                 {
                     final String messageText = getMessageText( validationType, referenceTo, node, file );
                     addMessage(
-                        node, file, validator, reporter, batchMode, messageText, severity, validationKey,
+                        node, file, validator, reporter, batchMode, messageText, severity, liferayPluginValidationType,
                         referenceTo.getQuerySpecificationId() );
                 }
             }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayDisplayDescriptorValidator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayDisplayDescriptorValidator.java
@@ -49,11 +49,11 @@ public class LiferayDisplayDescriptorValidator extends LiferayBaseValidator
             {
                 if( node.getNodeValue().matches( "\\s*" ) )
                 {
-                    final String validationKey = getValidationKey( ValidationType.SYNTAX_INVALID, file );
+                    final String liferayPluginValidationType = getLiferayPluginValidationType( ValidationType.SYNTAX_INVALID, file );
                     String validationMsg = MESSAGE_CATEGORY_NAME_CANNOT_BE_EMPTY;
 
                     addMessage(
-                        node, file, validator, reporter, batchMode, validationMsg, severity, validationKey );
+                        node, file, validator, reporter, batchMode, validationMsg, severity, liferayPluginValidationType );
                     return false;
                 }
             }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayHookDescriptorValidator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayHookDescriptorValidator.java
@@ -74,8 +74,8 @@ public class LiferayHookDescriptorValidator extends LiferayBaseValidator
                     if( validationMsg != null )
                     {
 
-                        final String validationKey = getValidationKey( ValidationType.SYNTAX_INVALID, file );
-                        addMessage( node, file, validator, reporter, batchMode, validationMsg, severity, validationKey );
+                        final String liferayPluginValidationType = getLiferayPluginValidationType( ValidationType.SYNTAX_INVALID, file );
+                        addMessage( node, file, validator, reporter, batchMode, validationMsg, severity, liferayPluginValidationType );
                         return false;
                     }
                 }
@@ -100,7 +100,7 @@ public class LiferayHookDescriptorValidator extends LiferayBaseValidator
                     addMessage(
                         node, file, validator, reporter, batchMode, valInfo.getValidationMessge(),
                         getServerity( valInfo.getValidationType(), file ),
-                        getValidationKey( valInfo.getValidationType(), file ) );
+                        getLiferayPluginValidationType( valInfo.getValidationType(), file ) );
                 }
 
                 return;
@@ -115,7 +115,7 @@ public class LiferayHookDescriptorValidator extends LiferayBaseValidator
                     addMessage(
                         node, file, validator, reporter, batchMode, valInfo.getValidationMessge(),
                         getServerity( valInfo.getValidationType(), file ),
-                        getValidationKey( valInfo.getValidationType(), file ) );
+                        getLiferayPluginValidationType( valInfo.getValidationType(), file ) );
                 }
 
                 return;

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayJspValidator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayJspValidator.java
@@ -64,7 +64,7 @@ public class LiferayJspValidator extends LiferayBaseValidator
 
     protected void addMessage(
         IDOMNode node, IFile file, IValidator validator, IReporter reporter, boolean batchMode, String messageText,
-        int severity, String validationKey, String querySpecificationId )
+        int severity, String liferayPluginValidationType, String querySpecificationId )
     {
         final String textContent = DOMUtils.getNodeValue( node );
         int startOffset = getStartOffset( node );
@@ -82,7 +82,7 @@ public class LiferayJspValidator extends LiferayBaseValidator
                 message.setAttribute( XMLSearchConstants.TEXT_CONTENT, textContent );
                 message.setAttribute( XMLSearchConstants.FULL_PATH, file.getFullPath().toPortableString() );
                 message.setAttribute( XMLSearchConstants.MARKER_TYPE, XMLSearchConstants.LIFERAY_JSP_MARKER_ID );
-                message.setAttribute( XMLSearchConstants.VALIDATION_KEY, validationKey );
+                message.setAttribute( XMLSearchConstants.LIFERAY_PLUGIN_VALIDATION_TYPE, liferayPluginValidationType );
                 message.setTargetObject( file );
                 reporter.addMessage( validator, message );
             }
@@ -134,13 +134,13 @@ public class LiferayJspValidator extends LiferayBaseValidator
     protected int getServerity( ValidationType validationType, IFile file )
     {
         int retval = -1;
-        String validationKey = getValidationKey( validationType, file );
+        String liferayPluginValidationType = getLiferayPluginValidationType( validationType, file );
 
-        if( validationKey != null )
+        if( liferayPluginValidationType != null )
         {
             retval =
                 Platform.getPreferencesService().getInt(
-                    PREFERENCE_NODE_QUALIFIER, validationKey, IMessage.NORMAL_SEVERITY,
+                    PREFERENCE_NODE_QUALIFIER, liferayPluginValidationType, IMessage.NORMAL_SEVERITY,
                     getScopeContexts( file.getProject() ) );
         }
         else
@@ -153,7 +153,7 @@ public class LiferayJspValidator extends LiferayBaseValidator
 
 
     @Override
-    protected String getValidationKey( ValidationType validationType, IFile file )
+    protected String getLiferayPluginValidationType( ValidationType validationType, IFile file )
     {
         String retval = null;
 
@@ -294,12 +294,12 @@ public class LiferayJspValidator extends LiferayBaseValidator
 
                             if( severity != ValidationMessage.IGNORE )
                             {
-                                final String validationKey = getValidationKey( validationType, file );
+                                final String liferayPluginValidationType = getLiferayPluginValidationType( validationType, file );
                                 final String querySpecificationId = referenceTo.getQuerySpecificationId();
                                 final String messageText = getMessageText( validationType, referenceTo, node, file );
 
                                 addMessage(
-                                    node, file, validator, reporter, batchMode, messageText, severity, validationKey,
+                                    node, file, validator, reporter, batchMode, messageText, severity, liferayPluginValidationType,
                                     querySpecificationId );
                             }
                         }
@@ -336,12 +336,12 @@ public class LiferayJspValidator extends LiferayBaseValidator
 
                     if( severity != ValidationMessage.IGNORE )
                     {
-                        final String validationKey = getValidationKey( validationType, file );
+                        final String liferayPluginValidationType = getLiferayPluginValidationType( validationType, file );
                         final String querySpecificationId = referenceTo.getQuerySpecificationId();
                         final String messageText = getMessageText( validationType, referenceTo, node, file );
 
                         addMessage(
-                            node, file, validator, reporter, batchMode, messageText, severity, validationKey,
+                            node, file, validator, reporter, batchMode, messageText, severity, liferayPluginValidationType,
                             querySpecificationId );
                     }
                 }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayPortletDescriptorValidator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/LiferayPortletDescriptorValidator.java
@@ -68,10 +68,10 @@ public class LiferayPortletDescriptorValidator extends LiferayBaseValidator
 
                 if( validationMsg != null )
                 {
-                    final String validationKey = getValidationKey( ValidationType.SYNTAX_INVALID, file );
+                    final String liferayPluginValidationType = getLiferayPluginValidationType( ValidationType.SYNTAX_INVALID, file );
 
                     addMessage(
-                        node, file, validator, reporter, batchMode, validationMsg, severity, validationKey );
+                        node, file, validator, reporter, batchMode, validationMsg, severity, liferayPluginValidationType );
                     return false;
                 }
             }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/PortletDescriptorValidator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/PortletDescriptorValidator.java
@@ -64,10 +64,10 @@ public class PortletDescriptorValidator extends LiferayBaseValidator
 
                 if( validationMsg != null )
                 {
-                    final String validationKey = getValidationKey( ValidationType.SYNTAX_INVALID, file );
+                    final String liferayPluginValidationType = getLiferayPluginValidationType( ValidationType.SYNTAX_INVALID, file );
 
                     addMessage(
-                        node, file, validator, reporter, batchMode, validationMsg, severity, validationKey );
+                        node, file, validator, reporter, batchMode, validationMsg, severity, liferayPluginValidationType );
                     return false;
                 }
             }

--- a/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/ServiceBuilderDescriptorValidator.java
+++ b/tools/plugins/com.liferay.ide.xml.search.ui/src/com/liferay/ide/xml/search/ui/validators/ServiceBuilderDescriptorValidator.java
@@ -82,10 +82,10 @@ public class ServiceBuilderDescriptorValidator extends LiferayBaseValidator
 
             if( validationMsg != null )
             {
-                final String validationKey = getValidationKey( ValidationType.SYNTAX_INVALID, file );
+                final String liferayPluginValidationType = getLiferayPluginValidationType( ValidationType.SYNTAX_INVALID, file );
 
                 addMessage(
-                    node, file, validator, reporter, batchMode, validationMsg, severity, validationKey );
+                    node, file, validator, reporter, batchMode, validationMsg, severity, liferayPluginValidationType );
                 return false;
             }
         }


### PR DESCRIPTION
change the way to check if an error/warning can be quick fixed now is looking through the error/warning type and check if it is mapped to types in preference validation page

change var name "validationKey" to "liferayPluginValidationType"
change method name "getValidationKey" to "getLiferayPluginValidationType"