### PR TITLE
IDE-1866 add the suspend validations setting file in sdk project

### DIFF
--- a/tools/plugins/com.liferay.ide.sdk.ui/build.properties
+++ b/tools/plugins/com.liferay.ide.sdk.ui/build.properties
@@ -4,4 +4,5 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                icons/,\
+			   files/,\
                OSGI-INF/

--- a/tools/plugins/com.liferay.ide.sdk.ui/build.properties
+++ b/tools/plugins/com.liferay.ide.sdk.ui/build.properties
@@ -4,5 +4,5 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                icons/,\
-			   files/,\
+               files/,\
                OSGI-INF/

--- a/tools/plugins/com.liferay.ide.sdk.ui/files/org.eclipse.wst.validation.prefs
+++ b/tools/plugins/com.liferay.ide.sdk.ui/files/org.eclipse.wst.validation.prefs
@@ -1,0 +1,9 @@
+DELEGATES_PREFERENCE=delegateValidatorList
+USER_BUILD_PREFERENCE=enabledBuildValidatorListorg.eclipse.wst.wsi.ui.internal.WSIMessageValidator;
+USER_MANUAL_PREFERENCE=enabledManualValidatorListorg.eclipse.wst.wsi.ui.internal.WSIMessageValidator;
+USER_PREFERENCE=overrideGlobalPreferencestruedisableAllValidationtrueversion1.2.600.v201501211647
+eclipse.preferences.version=1
+override=true
+suspend=true
+vals/org.eclipse.wst.xml.core.xml/groups=0107include08111contentType128org.eclipse.core.runtime.xmlT111contentType134org.eclipse.wst.xml.core.xmlsourceT111contentType134org.eclipse.wst.xml.core.xslsourceT111contentType134org.eclipse.jst.jsp.core.tldsourceT07fileext03xmlF111contentType134com.liferay.ide.poshi.functionfileF111contentType131com.liferay.ide.poshi.macrofileF111contentType134com.liferay.ide.poshi.testcasefileF0107exclude06113projectNature134org.eclipse.jst.j2ee.ejb.EJBNature113projectNature130org.eclipse.jst.j2ee.EARNature04file08.projectT0104file110.classpathT0104file110.settings/T0204file112dependenciesF02
+vf.version=3

--- a/tools/plugins/com.liferay.ide.sdk.ui/src/com/liferay/ide/sdk/ui/InstalledSDKsCompostite.java
+++ b/tools/plugins/com.liferay.ide.sdk.ui/src/com/liferay/ide/sdk/ui/InstalledSDKsCompostite.java
@@ -16,12 +16,15 @@
 package com.liferay.ide.sdk.ui;
 
 import com.liferay.ide.core.util.CoreUtil;
+import com.liferay.ide.core.util.FileUtil;
 import com.liferay.ide.core.util.StringPool;
 import com.liferay.ide.sdk.core.SDK;
 import com.liferay.ide.sdk.core.SDKManager;
 import com.liferay.ide.sdk.core.SDKUtil;
 import com.liferay.ide.ui.util.SWTUtil;
 
+import java.io.File;
+import java.net.URL;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +36,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
@@ -476,6 +481,22 @@ public class InstalledSDKsCompostite extends Composite
             try
             {
                 sdkProject.create( description, npm );
+
+                IPath settingFolderPath = sdkProject.getLocation().append( ".settings" ); //$NON-NLS-1$
+                File settingFolder = settingFolderPath.toFile();
+
+                if (!settingFolder.exists()) {
+                    settingFolder.mkdir();
+                }
+
+                URL url =
+                    FileLocator.toFileURL( SDKUIPlugin.getDefault().getBundle().getEntry(
+                        "files/org.eclipse.wst.validation.prefs" ) ); //$NON-NLS-1$
+
+                File file = new File( url.getFile() );
+
+                FileUtil.copyFileToDir( file, settingFolder );
+
                 sdkProject.open( npm );
             }
             catch( Exception e )


### PR DESCRIPTION
Hey Greg, because we remove the function for adding different sdk in 3.0 M1, so we need change two places for different versions.I am not sure you will merge this bug fix in 2.2.4
@yanan