### PR TITLE
Ide 2222

### DIFF
--- a/build/com.liferay.ide-repository/bundle/build.xml
+++ b/build/com.liferay.ide-repository/bundle/build.xml
@@ -263,7 +263,7 @@
                         <if>
                             <isset property="isMac" />
                             <then>
-                                <chmod file="${eclipse.dir}/Eclipse.app/Contents/MacOS/eclipse" perm="ugo+rx" />
+                                <chmod file="${work.dir}/Eclipse.app/Contents/MacOS/eclipse" perm="ugo+rx" />
                             </then>
                             <else>
                                 <chmod file="${eclipse.dir}/eclipse" perm="ugo+rx" />
@@ -425,7 +425,7 @@
         <if>
             <isset property="isMac" />
             <then>
-                <property name="eclipse.ini.dir" value="${work.dir}/eclipse/Eclipse.app/Contents/MacOS/eclipse.ini" />
+                <property name="eclipse.ini.dir" value="${work.dir}/Eclipse.app/Contents/MacOS/eclipse.ini" />
             </then>
             <else>
                 <property name="eclipse.ini.dir" value="${eclipse.dir}/eclipse.ini"/>

--- a/build/com.liferay.ide-repository/bundle/bundle.properties
+++ b/build/com.liferay.ide-repository/bundle/bundle.properties
@@ -9,9 +9,9 @@ builder.exe=${builder.dir}/eclipse
 updatesite=file:repository
 all.features=com.liferay.ide.eclipse.tools.feature.group,com.liferay.ide.alloy.feature.group,com.liferay.ide.maven.feature.group,com.liferay.ide.gradle.feature.group
 
-builder.zip.name=eclipse-standard-kepler-R-linux-gtk-x86_64.tar.gz
-builder.tar.name=eclipse-standard-kepler-R-linux-gtk-x86_64.tar
-builder.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/kepler/R/eclipse-standard-kepler-R-linux-gtk-x86_64.tar.gz
+builder.zip.name=eclipse-committers-mars-1-linux-gtk-x86_64.tar.gz
+builder.tar.name=eclipse-committers-mars-1-linux-gtk-x86_64.tar
+builder.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/mars/1/eclipse-committers-mars-1-linux-gtk-x86_64.tar.gz
 
 ## 32-bit OSes ##
 

--- a/build/com.liferay.ide-repository/bundle/bundle.properties
+++ b/build/com.liferay.ide-repository/bundle/bundle.properties
@@ -15,19 +15,19 @@ builder.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/
 
 ## 32-bit OSes ##
 
-eclipse.win32.zip.name=eclipse-jee-mars-R-win32.zip
-eclipse.win32.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-win32.zip
-eclipse.linux.zip.name=eclipse-jee-mars-R-linux-gtk.tar.gz
-eclipse.linux.tar.name=eclipse-jee-mars-R-linux-gtk.tar
-eclipse.linux.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-linux-gtk.tar.gz
+eclipse.win32.zip.name=eclipse-jee-mars-1-win32.zip
+eclipse.win32.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-win32.zip
+eclipse.linux.zip.name=eclipse-jee-mars-1-linux-gtk.tar.gz
+eclipse.linux.tar.name=eclipse-jee-mars-1-linux-gtk.tar
+eclipse.linux.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-linux-gtk.tar.gz
 
 ## 64-bit OSes
 
-eclipse.win64.zip.name=eclipse-jee-mars-R-win32-x86_64.zip
-eclipse.win64.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-win32-x86_64.zip
-eclipse.linux64.zip.name=eclipse-jee-mars-R-linux-gtk-x86_64.tar.gz
-eclipse.linux64.tar.name=eclipse-jee-mars-R-linux-gtk-x86_64.tar
-eclipse.linux64.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-linux-gtk-x86_64.tar.gz
-eclipse.macosx64.zip.name=eclipse-jee-mars-R-macosx-cocoa-x86_64.tar.gz
-eclipse.macosx64.tar.name=eclipse-jee-mars-R-macosx-cocoa-x86_64.tar
-eclipse.macosx64.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/R/eclipse-jee-mars-R-macosx-cocoa-x86_64.tar.gz
+eclipse.win64.zip.name=eclipse-jee-mars-1-win32-x86_64.zip
+eclipse.win64.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-win32-x86_64.zip
+eclipse.linux64.zip.name=eclipse-jee-mars-1-linux-gtk-x86_64.tar.gz
+eclipse.linux64.tar.name=eclipse-jee-mars-1-linux-gtk-x86_64.tar
+eclipse.linux64.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-linux-gtk-x86_64.tar.gz
+eclipse.macosx64.zip.name=eclipse-jee-mars-1-macosx-cocoa-x86_64.tar.gz
+eclipse.macosx64.tar.name=eclipse-jee-mars-1-macosx-cocoa-x86_64.tar
+eclipse.macosx64.zip.url=http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-macosx-cocoa-x86_64.tar.gz

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -27,7 +27,7 @@
     <name>Liferay IDE Parent</name>
 
     <properties>
-        <tycho-packaging-format>yyyyMMddHHmm</tycho-packaging-format>
+        <tycho-packaging-format>yyyyMMddHHmm'-m1'</tycho-packaging-format>
         <tycho-version>0.23.0</tycho-version>
         <tycho-extras-version>0.23.0</tycho-extras-version>
         <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/</orbit-site>


### PR DESCRIPTION
Sorry Greg, for the commit IDE-2220 update eclipse builder,

It still **failed to install on Mac** while "install-feature" target, error messages: 

install-all-features:
     [echo] file:repository
install-feature:
[ERROR] /var/lib/jenkins/jobs/liferay-ide/workspace/build/com.liferay.ide-repository/bundle/build.xml:297: exec returned: 13

And I tried with eclipse-mars-R-Committers, still failed. 
