### PR TITLE
remove blade.cli.jar properties

### DIFF
--- a/tools/plugins/com.liferay.ide.project.core/build.properties
+++ b/tools/plugins/com.liferay.ide.project.core/build.properties
@@ -7,5 +7,4 @@ bin.includes = META-INF/,\
                schema/,\
                OSGI-INF/,\
                lib/jackson-core-asl-1.9.13.jar,\
-               lib/jackson-mapper-asl-1.9.13.jar,\
-               lib/com.liferay.blade.cli.jar
+               lib/jackson-mapper-asl-1.9.13.jar


### PR DESCRIPTION
liferay-ide build failed since the following reason:

liferay-ide/workspace/tools/plugins/com.liferay.ide.project.core/build.properties: bin.includes value(s) [lib/com.liferay.blade.cli.jar] do not match any files. 
After checked in lib folder, there is no blade.cli.jar.