### PR TITLE
IDE-2252 add web project related config files

### DIFF
--- a/gradle/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleProjectProvider.java
+++ b/gradle/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleProjectProvider.java
@@ -217,6 +217,10 @@ public class GradleProjectProvider extends AbstractLiferayProjectProvider
             {
                 GradleUtil.importGradleProject( projecLocation.toFile(), monitor );
             }
+
+            IProject project = CoreUtil.getProject( projectName );
+
+            ModuleFacetUtil.addFacets( project, monitor );
         }
         catch( Exception e )
         {

--- a/gradle/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/ModuleFacetUtil.java
+++ b/gradle/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/ModuleFacetUtil.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ *******************************************************************************/
+
+package com.liferay.ide.gradle.core;
+
+import com.liferay.ide.core.util.FileUtil;
+
+import java.io.File;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+/**
+ * @author Andy Wu
+ */
+public class ModuleFacetUtil
+{
+
+    public static void addFacets( final IProject project, IProgressMonitor monitor ) throws CoreException
+    {
+        addNature( project, "org.eclipse.wst.common.modulecore.ModuleCoreNature", monitor );
+        addNature( project, "org.eclipse.wst.common.project.facet.core.nature", monitor );
+
+        addConfigFile( project );
+
+        project.refreshLocal( IResource.DEPTH_INFINITE, monitor );
+    }
+
+    private static void addConfigFile( final IProject project ) throws CoreException
+    {
+        String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<project-modules id=\"moduleCoreId\" project-version=\"1.5.0\">\n" +
+            "<wb-module deploy-name=\"PROJECT_NAME\">\n" + "<wb-resource deploy-path=\"/\" " +
+            "source-path=\"/src/main/resources/META-INF/resources\" " + "tag=\"defaultRootSource\"/>\n" +
+            "</wb-module>\n</project-modules>";
+
+        String finalContent = content.replace( "PROJECT_NAME", project.getName() );
+
+        File compoment = new File( project.getLocation().toFile(), ".settings/org.eclipse.wst.common.component" );
+
+        FileUtil.writeFile( compoment, finalContent.getBytes(), project.getName() );
+    }
+
+    private static void addNature( IProject project, String natureId, IProgressMonitor monitor ) throws CoreException
+    {
+        if( monitor != null && monitor.isCanceled() )
+        {
+            throw new OperationCanceledException();
+        }
+
+        if( !hasNature( project, natureId ) )
+        {
+            IProjectDescription description = project.getDescription();
+
+            String[] prevNatures = description.getNatureIds();
+            String[] newNatures = new String[prevNatures.length + 1];
+
+            System.arraycopy( prevNatures, 0, newNatures, 0, prevNatures.length );
+
+            newNatures[prevNatures.length] = natureId;
+
+            description.setNatureIds( newNatures );
+            project.setDescription( description, monitor );
+        }
+        else
+        {
+            if( monitor != null )
+            {
+                monitor.worked( 1 );
+            }
+        }
+    }
+
+    private static boolean hasNature( IProject project, String natureId )
+    {
+        try
+        {
+            if( !project.hasNature( natureId ) )
+            {
+                return false;
+            }
+        }
+        catch( CoreException e )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
hey Greg , I searched about jsp file finding and compiling mechanism and found this is the simple way to make the jsp include tag and compile works well in a no-web project.
Also we can add web related facets by calling eclipse facet api but it will add "Dynamic web module" facet to the project and when we call "add and remote" dialog , it will show another web project(same name as module project).
so I think it is better to not use facet api.
![duplicated projects](https://cloud.githubusercontent.com/assets/12250744/13562238/33b02a28-e471-11e5-8aed-581157ce6621.png)