### PR TITLE
fix logic issue

### DIFF
--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleModuleProjectImporter.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleModuleProjectImporter.java
@@ -37,35 +37,38 @@ public class GradleModuleProjectImporter extends AbstractLiferayProjectImporter
 
         File file = new File( location );
 
-        if( findGradleFile( file ) && findSettingsFile( file ) )
+        if( findGradleFile( file ) )
         {
-            retval = Status.OK_STATUS;
-        }
-        else
-        {
-            File parent = file.getParentFile();
-
-            while( parent != null )
+            if( findSettingsFile( file ) )
             {
-                if( findGradleFile( parent ) && findSettingsFile( file ) )
+                return Status.OK_STATUS;
+            }
+            else
+            {
+                File parent = file.getParentFile();
+
+                while( parent != null )
                 {
-                    retval = Status.OK_STATUS;
-                    break;
+                    if( findGradleFile( parent ) )
+                    {
+                        retval = new Status(
+                            IStatus.ERROR, GradleCore.PLUGIN_ID,
+                            "Location is not the root location of a multi-module project." );
+
+                        return retval;
+                    }
+
+                    parent = parent.getParentFile();
                 }
 
-                parent = parent.getParentFile();
+                if( retval == null )
+                {
+                    return Status.OK_STATUS;
+                }
             }
         }
 
-        if( retval == null )
-        {
-            retval = new Status(
-                IStatus.ERROR, GradleCore.PLUGIN_ID,
-                "Location is not the root location of a multi-module project." );
-        }
-
         return retval;
-
     }
 
     private boolean findFile( File dir, String name )

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ImportLiferayModuleProjectOpMethods.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ImportLiferayModuleProjectOpMethods.java
@@ -77,7 +77,7 @@ public class ImportLiferayModuleProjectOpMethods
                 retval = StatusBridge.create( Status.createStatus( Severity.OK, importer.getBuildType() ) );
                 break;
             }
-            else if( status.getSeverity() == IStatus.WARNING )
+            else if( status.getSeverity() == IStatus.ERROR )
             {
                 retval = StatusBridge.create( Status.createStatus( Severity.ERROR, status.getMessage() ) );
                 break;


### PR DESCRIPTION
hi @gamerson  , this is my logic in code:
1. if the location has both settings.gradle and build.gradle , it is a root project.
2. if only has build.gradle file and I will check all parent dirs to find build.gradle file , 
          if found , it is a child project and I will give an error.
          if not , it is still a root project..
3. if it has neither , it is not a gradle project and I will return null to let next importer to check(now we only have one importer although)