### PR TITLE
IDE-2794 add target platform core API and apply

### DIFF
--- a/tools/plugins/com.liferay.ide.project.core/META-INF/MANIFEST.MF
+++ b/tools/plugins/com.liferay.ide.project.core/META-INF/MANIFEST.MF
@@ -40,7 +40,8 @@ Require-Bundle: org.eclipse.wst.common.project.facet.core;bundle-version="[1.4.1
  biz.aQute.bndlib,
  biz.aQute.repository,
  biz.aQute.remote.api,
- org.eclipse.sapphire.java;bundle-version="[9,10)"
+ org.eclipse.sapphire.java;bundle-version="[9,10)",
+ org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: com.liferay.ide.project.core,

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/ITargetPlatformConstant.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/ITargetPlatformConstant.java
@@ -1,0 +1,13 @@
+
+package com.liferay.ide.project.core;
+
+/**
+ * @author Lovett Li
+ */
+public interface ITargetPlatformConstant
+{
+
+    String CURRENT_TARGETFORM_VERSION = "current_targetplatform_version";
+    String DEFAULT_TARGETFORM_VERSION = "GA2";
+
+}

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ServiceCommand.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ServiceCommand.java
@@ -18,6 +18,7 @@ package com.liferay.ide.project.core.modules;
 import aQute.remote.api.Agent;
 
 import com.liferay.ide.project.core.ProjectCore;
+import com.liferay.ide.project.core.util.TargetPlatformUtil;
 import com.liferay.ide.server.core.portal.BundleSupervisor;
 import com.liferay.ide.server.core.portal.PortalServerBehavior;
 
@@ -197,11 +198,11 @@ public class ServiceCommand
 
         if( _serviceName == null )
         {
-            result = getStaticServices();
+            result = TargetPlatformUtil.getServicesList();
         }
         else
         {
-            result = getStaticServiceBundle( _serviceName );
+            result = TargetPlatformUtil.getServiceBundle( _serviceName );
         }
 
         return result;
@@ -232,35 +233,6 @@ public class ServiceCommand
         supervisor.getAgent().stdin( "services" );
 
         return parseService( supervisor.getOutInfo() );
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private String[] getStaticServiceBundle( String _serviceName ) throws Exception
-    {
-        final File servicesFile = checkStaticServicesFile();
-        final ObjectMapper mapper = new ObjectMapper();
-
-        Map<String, List<String>> map = mapper.readValue( servicesFile, Map.class );
-        List<String> serviceBundle = map.get( _serviceName );
-
-        if( serviceBundle != null && serviceBundle.size() != 0 )
-        {
-            return (String[]) serviceBundle.toArray( new String[serviceBundle.size()] );
-        }
-
-        return null;
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private String[] getStaticServices() throws Exception
-    {
-        final File servicesFile = checkStaticServicesFile();
-        final ObjectMapper mapper = new ObjectMapper();
-
-        Map<String, String[]> map = mapper.readValue( servicesFile, Map.class );
-        String[] services = map.keySet().toArray( new String[0] );
-
-        return services;
     }
 
     private void updateServicesStaticFile( final String[] servicesList, final BundleSupervisor supervisor ) throws Exception

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ServiceWrapperCommand.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/ServiceWrapperCommand.java
@@ -2,6 +2,7 @@ package com.liferay.ide.project.core.modules;
 
 import com.liferay.ide.core.util.FileListing;
 import com.liferay.ide.project.core.ProjectCore;
+import com.liferay.ide.project.core.util.TargetPlatformUtil;
 import com.liferay.ide.server.core.portal.PortalRuntime;
 
 import java.io.File;
@@ -33,10 +34,17 @@ public class ServiceWrapperCommand
 {
 
     private final IServer _server;
+    private String _serviceWrapperName;
 
     public ServiceWrapperCommand( IServer server )
     {
         _server = server;
+    }
+
+    public ServiceWrapperCommand( IServer _server, String _serviceWrapperName )
+    {
+        this._server = _server;
+        this._serviceWrapperName = _serviceWrapperName;
     }
 
     public String[] getServiceWrapper() throws Exception
@@ -44,7 +52,7 @@ public class ServiceWrapperCommand
 
         if( _server == null )
         {
-            return getStaticServiceWrapper();
+            return getServiceWrapperFromTargetPlatform();
         }
         else
         {
@@ -185,24 +193,20 @@ public class ServiceWrapperCommand
         }
     }
 
-    @SuppressWarnings( "unchecked" )
-    private String[] getStaticServiceWrapper() throws Exception
+    private String[] getServiceWrapperFromTargetPlatform() throws Exception
     {
-        final URL url =
-            FileLocator.toFileURL( ProjectCore.getDefault().getBundle().getEntry( "OSGI-INF/wrappers-static.json" ) );
-        final File servicesFile = new File( url.getFile() );
+        String[] result;
 
-        if( servicesFile.exists() )
+        if( _serviceWrapperName == null )
         {
-            final ObjectMapper mapper = new ObjectMapper();
-
-            List<String> map = mapper.readValue( servicesFile, List.class );
-            String[] wrappers = map.toArray( new String[0] );
-
-            return wrappers;
+            result = TargetPlatformUtil.getServiceWrapperList();
+        }
+        else
+        {
+            result = TargetPlatformUtil.getServiceWrapperBundle( _serviceWrapperName );
         }
 
-        throw new FileNotFoundException( "can't find static services file wrapper-static.json" );
+        return result;
     }
 
     private void updateServiceWrapperStaticFile( final String[] wrapperList ) throws Exception

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/util/TargetPlatformUtil.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/util/TargetPlatformUtil.java
@@ -1,0 +1,155 @@
+
+package com.liferay.ide.project.core.util;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+import com.liferay.ide.project.core.ITargetPlatformConstant;
+import com.liferay.ide.project.core.ProjectCore;
+
+/**
+ * @author Lovett Li
+ */
+public class TargetPlatformUtil
+{
+
+    public static String[] getServicesList() throws Exception
+    {
+        File tpIndexFile = checkCurrentTargetPlatform( "service" );
+
+        return getServicesNameList( tpIndexFile );
+    }
+
+    public static String[] getServiceBundle( String serviceName ) throws Exception
+    {
+        File tpIndexFile = checkCurrentTargetPlatform( "service" );
+
+        return getBundleAndVersion( tpIndexFile , serviceName);
+    }
+
+    public static String[] getServiceWrapperList() throws Exception
+    {
+
+        File tpIndexFile = checkCurrentTargetPlatform( "servicewrapper" );
+
+        return getServicesNameList( tpIndexFile );
+    }
+
+    public static String[] getServiceWrapperBundle( String servicewrapperName ) throws Exception
+    {
+
+        File tpIndexFile = checkCurrentTargetPlatform( "servicewrapper" );
+
+        return getBundleAndVersion( tpIndexFile , servicewrapperName);
+    }
+
+    private static File checkCurrentTargetPlatform( String type ) throws IOException
+    {
+        ScopedPreferenceStore preferenceStore =
+            new ScopedPreferenceStore( InstanceScope.INSTANCE, ProjectCore.PLUGIN_ID );
+        String currentVersion = preferenceStore.getString( ITargetPlatformConstant.CURRENT_TARGETFORM_VERSION );
+
+        if( currentVersion.equals( "" ) )
+        {
+            return useSpecificTargetPlatform( ITargetPlatformConstant.DEFAULT_TARGETFORM_VERSION.toLowerCase(), type );
+        }
+        else
+        {
+            currentVersion = preferenceStore.getString( ITargetPlatformConstant.CURRENT_TARGETFORM_VERSION ).replace(
+                "[", "" ).replace( "]", "" ).toLowerCase();
+
+            return useSpecificTargetPlatform( currentVersion, type );
+        }
+    }
+
+    private static File useSpecificTargetPlatform( String currentVersion, String type ) throws IOException
+    {
+        URL url;
+        url = FileLocator.toFileURL(
+            ProjectCore.getDefault().getBundle().getEntry( "OSGI-INF/target-platform/liferay-" + currentVersion ) );
+        final File tpFolder = new File( url.getFile() );
+
+        File[] listFiles = tpFolder.listFiles( new FilenameFilter()
+        {
+
+            @Override
+            public boolean accept( File dir, String name )
+            {
+                if( type.equals( "service" ) && name.endsWith( "services.json" ) )
+                {
+                    return true;
+                }
+                if( type.equals( "servicewrapper" ) && name.endsWith( "servicewrappers.json" ) )
+                {
+                    return true;
+                }
+                return false;
+            }
+        } );
+
+        return listFiles[0];
+
+    }
+
+    public static List<String> getAllTargetPlatfromVersion() throws IOException
+    {
+        final URL url =
+            FileLocator.toFileURL( ProjectCore.getDefault().getBundle().getEntry( "OSGI-INF/target-platform" ) );
+        final File targetPlatfolder = new File( url.getFile() );
+        final List<String> tpVersionList = new ArrayList<>();
+
+        if( targetPlatfolder.isDirectory() )
+        {
+            File[] tpVersionFolder = targetPlatfolder.listFiles();
+
+            if( tpVersionFolder != null )
+            {
+                for( File tp : tpVersionFolder )
+                {
+                    String tpVersion = tp.getName().split( "-" )[1].toUpperCase();
+                    tpVersionList.add( tpVersion );
+                }
+            }
+        }
+
+        return tpVersionList;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static String[] getServicesNameList( File tpFile ) throws Exception
+    {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        Map<String, String[]> map = mapper.readValue( tpFile, Map.class );
+        String[] services = map.keySet().toArray( new String[0] );
+
+        return services;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static String[] getBundleAndVersion( File tpFile, String _serviceName ) throws Exception
+    {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        Map<String, List<String>> map = mapper.readValue( tpFile, Map.class );
+        List<String> serviceBundle = map.get( _serviceName );
+
+        if( serviceBundle != null && serviceBundle.size() != 0 )
+        {
+            return (String[]) serviceBundle.toArray( new String[serviceBundle.size()] );
+        }
+
+        return null;
+    }
+
+}

--- a/tools/plugins/com.liferay.ide.project.ui/plugin.xml
+++ b/tools/plugins/com.liferay.ide.project.ui/plugin.xml
@@ -1010,6 +1010,12 @@
             id="com.liferay.ide.project.ui.pref.bladeCLIPreferencePage"
             name="Blade">
       </page>
+      <page
+            category="com.liferay.ide.ui.preferences.liferay"
+            class="com.liferay.ide.project.ui.pref.TargetPlatformSettingsPage"
+            id="com.liferay.ide.project.ui.targetPlatformSettingsPage"
+            name="Target Platform">
+      </page>
    </extension>
 
    <extension

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/pref/TargetPlatformSettingsPage.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/pref/TargetPlatformSettingsPage.java
@@ -1,0 +1,132 @@
+
+package com.liferay.ide.project.ui.pref;
+
+import java.io.IOException;
+
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+import com.liferay.ide.project.core.ITargetPlatformConstant;
+import com.liferay.ide.project.core.ProjectCore;
+import com.liferay.ide.project.core.util.TargetPlatformUtil;
+
+/**
+ * @author Lovett Li
+ */
+public class TargetPlatformSettingsPage extends PreferencePage implements IWorkbenchPreferencePage
+{
+
+    public static final String PROJECT_UI_TARGETPLATFORM_PAGE_ID =
+        "com.liferay.ide.project.ui.targetPlatformSettingsPage";
+    private ComboViewer targetPlatFormVersion;
+    private ScopedPreferenceStore preferenceStore;
+
+    public TargetPlatformSettingsPage()
+    {
+        super();
+        preferenceStore = new ScopedPreferenceStore( InstanceScope.INSTANCE, ProjectCore.PLUGIN_ID );
+    }
+
+    @Override
+    public void init( IWorkbench workbench )
+    {
+    }
+
+    private void initvaules()
+    {
+        preferenceStore.getString( ITargetPlatformConstant.CURRENT_TARGETFORM_VERSION );
+
+        IPreferenceStore store = getPreStore();
+        String version;
+
+        if( store != null )
+        {
+            version = store.getString( ITargetPlatformConstant.CURRENT_TARGETFORM_VERSION ).replace( "[", "" ).replace(
+                "]", "" );
+
+            if( version == null || version.equals( "" ) )
+            {
+                version = ITargetPlatformConstant.DEFAULT_TARGETFORM_VERSION;
+            }
+        }
+        else
+        {
+            version = ITargetPlatformConstant.DEFAULT_TARGETFORM_VERSION;
+        }
+
+        final ISelection selection = new StructuredSelection( version );
+        targetPlatFormVersion.setSelection( selection );
+    }
+
+    @Override
+    protected Control createContents( Composite parent )
+    {
+        Composite comp = new Composite( parent, SWT.NONE );
+
+        GridLayout layout = new GridLayout( 2, false );
+        layout.horizontalSpacing = 10;
+        comp.setLayout( layout );
+
+        new Label( comp, SWT.NONE ).setText( "Liferay Target Platform Version:" );
+
+        targetPlatFormVersion = new ComboViewer( comp, SWT.READ_ONLY );
+        targetPlatFormVersion.setLabelProvider( new LabelProvider()
+        {
+
+            @Override
+            public String getText( Object element )
+            {
+                return element.toString();
+            }
+        } );
+        targetPlatFormVersion.setContentProvider( new ArrayContentProvider() );
+
+        // parse OSGI-INF/target-platform folder get data of version
+        try
+        {
+            targetPlatFormVersion.setInput( TargetPlatformUtil.getAllTargetPlatfromVersion() );
+        }
+        catch( IOException e )
+        {
+        }
+
+        initvaules();
+
+        return comp;
+    }
+
+    @Override
+    public boolean performOk()
+    {
+        boolean result = super.performOk();
+        storeValues();
+
+        return result;
+    }
+
+    private void storeValues()
+    {
+        preferenceStore.setValue(
+            ITargetPlatformConstant.CURRENT_TARGETFORM_VERSION, targetPlatFormVersion.getSelection().toString() );
+    }
+
+    private IPreferenceStore getPreStore()
+    {
+        return preferenceStore;
+    }
+
+}


### PR DESCRIPTION
User can easily change target platform according to eclipse preferences page select Liferay/Target Platform change list.
We can also easily update target platform index file just add new index file usage name of specification then ide will update UI list and don't need modify our code.