### PR TITLE
IDE-2853 add filter to migration view avoid certain problem be showed

### DIFF
--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/FileUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/FileUtil.java
@@ -57,6 +57,7 @@ import org.xml.sax.ErrorHandler;
  * @author Greg Amerson
  * @author Cindy Li
  * @author Simon Jiang
+ * @author Lovett Li
  */
 public class FileUtil
 {
@@ -704,6 +705,15 @@ public class FileUtil
         }
 
         return bytesTotal;
+    }
+
+    public static IFile convertFileToIFile( File file )
+    {
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IPath location = Path.fromOSString( file.getAbsolutePath() );
+        IFile ifile = workspace.getRoot().getFileForLocation( location );
+
+        return ifile;
     }
 
     private static class Msgs extends NLS

--- a/tools/plugins/com.liferay.ide.project.ui/plugin.xml
+++ b/tools/plugins/com.liferay.ide.project.ui/plugin.xml
@@ -1470,6 +1470,13 @@
             </enablement>
          </commonWizard>
       </navigatorContent>
+      <commonFilter
+        description="Hides copy-request-parameters problem"
+        id="com.liferay.commonFilter.hidecp"
+        name="LPS-54798 copy-request-parameters problem"
+        class="com.liferay.ide.project.ui.migration.MigrationProblemFilter"
+        activeByDefault="false">
+    </commonFilter>
    </extension>
    <extension
          point="org.eclipse.ui.navigator.viewer">
@@ -1480,6 +1487,7 @@
                   isRoot="true"
                   pattern="com.liferay.ide.project.ui.migration.content">
             </contentExtension>
+            <contentExtension pattern="com.liferay.commonFilter.hidecp"/>
          </includes>
       </viewerContentBinding>
       <viewerContentBinding

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationProblemFilter.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationProblemFilter.java
@@ -1,0 +1,55 @@
+package com.liferay.ide.project.ui.migration;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+
+import com.liferay.blade.api.Problem;
+import com.liferay.ide.core.util.FileUtil;
+import com.liferay.ide.project.core.upgrade.FileProblems;
+import com.liferay.ide.project.ui.ProjectUI;
+
+/**
+ * @author Lovett Li
+ */
+public class MigrationProblemFilter extends ViewerFilter
+{
+
+    @Override
+    public boolean select( Viewer viewer, Object parentElement, Object element )
+    {
+        if( element instanceof FileProblems )
+        {
+            List<Problem> problems = ( (FileProblems) element ).getProblems();
+
+            for( Problem problem : problems )
+            {
+                if( problem.getTicket().equals( "LPS-54798" ) )
+                {
+                    problem.setStatus( Problem.STATUS_IGNORE );
+
+                    try
+                    {
+                        IMarker findMarker =
+                            FileUtil.convertFileToIFile( problem.getFile() ).findMarker( problem.getMarkerId() );
+
+                        if( findMarker != null )
+                        {
+                            findMarker.delete();
+                        }
+                    }
+                    catch( CoreException e )
+                    {
+                        ProjectUI.logError( e );
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
Hey Greg.
This pull request mainly resolved this problem `"copy-request-parameters init parameter’s default value" ` always be showed and we are not able to fix it. Because of this problem just notice user portal changed some default value of configuration.
We discussed this problem and design to add a filter for these special problem that users have no ability to fix. In migration view they can choose filter to block these problems which will not effect their project compilation.
