### PR TITLE
Using two steps auto correct actions instead

### DIFF
--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/AutoCorrectAction.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/AutoCorrectAction.java
@@ -119,9 +119,8 @@ public class AutoCorrectAction extends ProblemAction
 
                     if( !projectName.equals( "" ) )
                     {
-                            migrateHandler.findMigrationProblems( new Path[] { path }, new String[] { projectName } );
+                        migrateHandler.findMigrationProblems( new Path[] { path }, new String[] { projectName } );
                     }
-
                 }
                 catch( InvalidSyntaxException e )
                 {

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/AutoCorrectSingleFileAction.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/AutoCorrectSingleFileAction.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ *******************************************************************************/
+
+package com.liferay.ide.project.ui.migration;
+
+import com.liferay.blade.api.AutoMigrateException;
+import com.liferay.blade.api.AutoMigrator;
+import com.liferay.blade.api.MigrationConstants;
+import com.liferay.blade.api.Problem;
+import com.liferay.ide.core.util.MarkerUtil;
+import com.liferay.ide.project.core.upgrade.FileProblems;
+import com.liferay.ide.project.ui.ProjectUI;
+import com.liferay.ide.project.ui.upgrade.animated.FindBreakingChangesPage;
+import com.liferay.ide.project.ui.upgrade.animated.Page;
+import com.liferay.ide.project.ui.upgrade.animated.UpgradeView;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.ui.actions.SelectionProviderAction;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * @author Terry Jia
+ */
+public class AutoCorrectSingleFileAction extends SelectionProviderAction
+{
+
+    public AutoCorrectSingleFileAction( ISelectionProvider provider )
+    {
+        super( provider, "Correct automatically" );
+    }
+
+    public void run()
+    {
+        final FindBreakingChangesPage page =
+            UpgradeView.getPage( Page.FINDBREACKINGCHANGES_PAGE_ID, FindBreakingChangesPage.class );
+        final TreeViewer treeViewer = page.getTreeViewer();
+
+        Object selection = treeViewer.getStructuredSelection().getFirstElement();
+
+        if( selection instanceof FileProblems )
+        {
+            FileProblems fileProblems = (FileProblems) selection;
+
+            IResource file = MigrationUtil.getIResourceFromFile( fileProblems.getFile() );
+
+            if( file != null )
+            {
+                MarkerUtil.clearMarkers( file, MigrationConstants.MARKER_TYPE, null );
+            }
+
+            final BundleContext context = FrameworkUtil.getBundle( AutoCorrectAction.class ).getBundleContext();
+
+            new WorkspaceJob( "Auto correcting all of migration problem for this file." )
+            {
+
+                @Override
+                public IStatus runInWorkspace( IProgressMonitor monitor )
+                {
+                    IStatus retval = Status.OK_STATUS;
+                    try
+                    {
+                        List<Problem> problems = fileProblems.getProblems();
+                        for( Problem problem : problems )
+                        {
+                            if( problem.autoCorrectContext != null )
+                            {
+                                final String autoCorrectKey = problem.autoCorrectContext.substring(
+                                    0, problem.autoCorrectContext.indexOf( ":" ) );
+
+                                final Collection<ServiceReference<AutoMigrator>> refs = context.getServiceReferences(
+                                    AutoMigrator.class, "(auto.correct=" + autoCorrectKey + ")" );
+
+                                for( ServiceReference<AutoMigrator> ref : refs )
+                                {
+                                    final AutoMigrator autoMigrator = context.getService( ref );
+                                    autoMigrator.correctProblems( problem.file, problems );
+                                }
+
+                                final IResource file = MigrationUtil.getIResourceFromProblem( problem );
+
+                                file.refreshLocal( IResource.DEPTH_ONE, monitor );
+                            }
+                        }
+                    }
+                    catch( InvalidSyntaxException e )
+                    {
+                    }
+                    catch( AutoMigrateException | CoreException e )
+                    {
+                        return retval = ProjectUI.createErrorStatus( "Unable to auto correct problem", e );
+                    }
+                    return retval;
+                }
+            }.schedule();;
+        }
+    }
+
+    @Override
+    public void selectionChanged( IStructuredSelection selection )
+    {
+        Object element = selection.getFirstElement();
+
+        if( element instanceof FileProblems )
+        {
+            setEnabled( true );
+
+            return;
+        }
+
+        setEnabled( false );
+    }
+}

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrateProjectHandler.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrateProjectHandler.java
@@ -27,7 +27,6 @@ import com.liferay.ide.project.core.upgrade.IgnoredProblemsContainer;
 import com.liferay.ide.project.core.upgrade.MigrationProblems;
 import com.liferay.ide.project.core.upgrade.UpgradeAssistantSettingsUtil;
 import com.liferay.ide.project.core.upgrade.UpgradeProblems;
-import com.liferay.ide.project.core.util.ProjectUtil;
 import com.liferay.ide.project.ui.ProjectUI;
 import com.liferay.ide.project.ui.upgrade.animated.FindBreakingChangesPage;
 import com.liferay.ide.project.ui.upgrade.animated.Page;
@@ -46,7 +45,6 @@ import java.util.Set;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -389,7 +387,7 @@ public class MigrateProjectHandler extends AbstractHandler
 
                     if( isSingleFile )
                     {
-                       refreshViewer(allProblems);
+                        refreshViewer( allProblems );
                     }
                     else
                     {
@@ -559,24 +557,9 @@ public class MigrateProjectHandler extends AbstractHandler
 
     private void clearFileMarkers( File file )
     {
-        IProject[] projects = ProjectUtil.getAllPluginsSDKProjects();
+        IResource resource = MigrationUtil.getIResourceFromFile( file );
 
-        for( IProject project : projects )
-        {
-            String filePath = file.getPath().replaceAll( "\\\\", "/" );
-            String projectPath = project.getLocation().toString();
-            if( filePath.startsWith( projectPath ) )
-            {
-                int i = filePath.indexOf( projectPath ) + projectPath.length();
-                String projectFilePath = filePath.substring( i, filePath.length() );
-                IFile projectFile = project.getFile( projectFilePath );
-                if( projectFile.exists() )
-                {
-                    MarkerUtil.clearMarkers( projectFile, MigrationConstants.MARKER_TYPE, null );
-                }
-                break;
-            }
-        }
+        MarkerUtil.clearMarkers( resource, MigrationConstants.MARKER_TYPE, null );
     }
 
     protected void refreshViewer(List<Problem> allProblems)

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationUtil.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationUtil.java
@@ -45,8 +45,6 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
-import org.eclipse.ui.texteditor.MarkerUtilities;
-
 
 /**
  * @author Gregory Amerson

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/upgrade/animated/FindBreakingChangesPage.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/upgrade/animated/FindBreakingChangesPage.java
@@ -20,8 +20,8 @@ import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.project.core.upgrade.FileProblems;
 import com.liferay.ide.project.core.upgrade.UpgradeAssistantSettingsUtil;
 import com.liferay.ide.project.ui.ProjectUI;
-import com.liferay.ide.project.ui.migration.AutoCorrectAction;
 import com.liferay.ide.project.ui.migration.AutoCorrectAllAction;
+import com.liferay.ide.project.ui.migration.AutoCorrectSingleFileAction;
 import com.liferay.ide.project.ui.migration.IgnoreAction;
 import com.liferay.ide.project.ui.migration.IgnoreAlwaysAction;
 import com.liferay.ide.project.ui.migration.MarkDoneAction;
@@ -32,6 +32,7 @@ import com.liferay.ide.project.ui.migration.MigrationProblemsContainer;
 import com.liferay.ide.project.ui.migration.MigrationUtil;
 import com.liferay.ide.project.ui.migration.MigratorComparator;
 import com.liferay.ide.project.ui.migration.ProblemsContainer;
+import com.liferay.ide.project.ui.migration.RefindAction;
 import com.liferay.ide.project.ui.migration.RemoveAction;
 import com.liferay.ide.project.ui.migration.RunMigrationToolAction;
 import com.liferay.ide.project.ui.pref.MigrationProblemPreferencePage;
@@ -142,8 +143,15 @@ public class FindBreakingChangesPage extends Page implements IDoubleClickListene
         _treeViewer.setInput( getInitialInput() );
 
         MenuManager menuMgr = new MenuManager();
+
         IAction removeAction = new RemoveAction( _treeViewer );
+        IAction autoCorrectFileAction = new AutoCorrectSingleFileAction(_treeViewer);
+        IAction refindAction = new RefindAction(_treeViewer);
+
         menuMgr.add( removeAction );
+        menuMgr.add( autoCorrectFileAction );
+        menuMgr.add( refindAction );
+
         Menu menu = menuMgr.createContextMenu( _treeViewer.getTree() );
 
         _treeViewer.getTree().setMenu( menu );
@@ -458,12 +466,12 @@ public class FindBreakingChangesPage extends Page implements IDoubleClickListene
         IAction markUndoneAction = new MarkUndoneAction( _problemsViewer );
         IAction ignoreAction = new IgnoreAction( _problemsViewer );
         IAction ignoreAlways = new IgnoreAlwaysAction( _problemsViewer );
-        IAction autoCorrectAction = new AutoCorrectAction( _problemsViewer );
+        //IAction autoCorrectAction = new AutoCorrectAction( _problemsViewer );
 
         menuMgr.add( markDoneAction );
         menuMgr.add( markUndoneAction );
         menuMgr.add( ignoreAction );
-        menuMgr.add( autoCorrectAction );
+        //menuMgr.add( autoCorrectAction );
         menuMgr.add( ignoreAlways );
         Menu menu = menuMgr.createContextMenu( table );
         table.setMenu( menu );


### PR DESCRIPTION
@gamerson in this commit, I removed the "auto correct action" on "Problem" and added two actions on "File" instead. As eclipse uses "some job" to delete markers, we can't handle it in our code, thus it causes some serious marker problems. So I gave the action to auto correct for one entire file.