### PR TITLE
IDE-2999 fix merging parameters with space

### DIFF
--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalJBossBundle.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalJBossBundle.java
@@ -129,15 +129,14 @@ public class PortalJBossBundle extends AbstractPortalBundle implements PortalBun
     {
         final List<String> args = new ArrayList<String>();
 
-        args.add( "-mp");
-        args.add( "\"" + this.bundlePath.toPortableString() +  "/modules" + "\"" );
-        args.add( "-jaxpmodule");
+        args.add( "-mp \"" + this.bundlePath.toPortableString() +  "/modules" + "\"");
+        args.add( "-jaxpmodule" );
         args.add( "javax.xml.jaxp-provider" );
         args.add( "org.jboss.as.standalone" );
-        args.add( "-b");
+        args.add( "-b" );
         args.add( "localhost" );
         args.add( "--server-config=standalone.xml" );
-        args.add( "-Djboss.server.base.dir=" + "\"" + this.bundlePath.toPortableString() + "/standalone/"+ "\"");
+        args.add( "-Djboss.server.base.dir=" + "\"" + this.bundlePath.toPortableString() + "/standalone/"+ "\"" );
 
         return args.toArray( new String[0] );
 
@@ -148,8 +147,7 @@ public class PortalJBossBundle extends AbstractPortalBundle implements PortalBun
     {
         final List<String> args = new ArrayList<String>();
 
-        args.add( "-mp" );
-        args.add( "\"" + this.bundlePath.toPortableString() +  "/modules" + "\"" );
+        args.add( "-mp \"" + this.bundlePath.toPortableString() +  "/modules" + "\"" );
         args.add( "org.jboss.as.cli" );
         args.add( "--controller=localhost:" + 9999 );
         args.add( "--connect" );

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerBehavior.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerBehavior.java
@@ -279,11 +279,22 @@ public class PortalServerBehavior extends ServerBehaviourDelegate
         {
             retval = orgArgsString == null ? "" : orgArgsString;
 
+            String xbootClasspath = "";
+
             // replace and null out all newArgs that already exist
             final int size = newArgs.length;
 
             for( int i = 0; i < size; i++ )
             {
+                if( newArgs[i].startsWith( "-Xbootclasspath" ) )
+                {
+                    xbootClasspath = xbootClasspath + newArgs[i] + " ";
+
+                    newArgs[i] = null;
+
+                    continue;
+                }
+
                 final int ind = newArgs[i].indexOf( " " );
                 final int ind2 = newArgs[i].indexOf( "=" );
 
@@ -460,6 +471,24 @@ public class PortalServerBehavior extends ServerBehaviourDelegate
                     retval += newArgs[i];
                 }
             }
+
+            //delete xbootclasspath
+            int xbootIndex = retval.lastIndexOf( "-Xbootclasspath" );
+
+            while( xbootIndex != -1 )
+            {
+                String head = retval.substring( 0, xbootIndex );
+
+                int tailIndex = getNextToken( retval, xbootIndex );
+
+                String tail = retval.substring( tailIndex == retval.length() ? retval.length() : tailIndex + 1 );
+
+                retval = head+tail;
+
+                xbootIndex = retval.lastIndexOf( "-Xbootclasspath" );
+            }
+
+            retval = retval+ " " + xbootClasspath;
         }
 
         return retval;

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalWildFlyBundle.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalWildFlyBundle.java
@@ -54,8 +54,7 @@ public class PortalWildFlyBundle extends PortalJBossBundle
     {
         final List<String> args = new ArrayList<String>();
 
-        args.add( "-mp" );
-        args.add( "\"" + this.bundlePath.toPortableString() + "/modules" + "\"" );
+        args.add( "-mp \"" + this.bundlePath.toPortableString() + "/modules" + "\"" );
         args.add( "org.jboss.as.cli" );
         args.add( "--connect" );
         args.add( "--controller=localhost:" + 9990 );


### PR DESCRIPTION
hey Greg , the PortalServerBehavior.mergeArguments method only support there style arguments , 
1. -a bc (bc can include space)
2. a=b (b can include space)
3. abc (abc can include space)

and jobss  arguments has such style : -abc (abs incudes space)(eg. -Xbootclasspath/p:"D:/dev java/test") and this method can't handle , (be recognized as:  
-Xbootclasspath/p:"D:/dev 
java/test" )
so I just deal such parameter specially , when merging i ignore all such parameters , and after merging , I just remove all existing ones ,and append new ones.

So in this way , if user add new Xbootclasspath , it will be ignored. is this ok ? or should I need to check if new classpath addded ?