### PR TITLE
IDE-2999 don't delete old xbootclasspath if new args don't include them

### DIFF
--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerBehavior.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerBehavior.java
@@ -472,23 +472,26 @@ public class PortalServerBehavior extends ServerBehaviourDelegate
                 }
             }
 
-            //delete xbootclasspath
-            int xbootIndex = retval.lastIndexOf( "-Xbootclasspath" );
-
-            while( xbootIndex != -1 )
+            if( !CoreUtil.isNullOrEmpty( xbootClasspath ) )
             {
-                String head = retval.substring( 0, xbootIndex );
+                // delete xbootclasspath
+                int xbootIndex = retval.lastIndexOf( "-Xbootclasspath" );
 
-                int tailIndex = getNextToken( retval, xbootIndex );
+                while( xbootIndex != -1 )
+                {
+                    String head = retval.substring( 0, xbootIndex );
 
-                String tail = retval.substring( tailIndex == retval.length() ? retval.length() : tailIndex + 1 );
+                    int tailIndex = getNextToken( retval, xbootIndex );
 
-                retval = head+tail;
+                    String tail = retval.substring( tailIndex == retval.length() ? retval.length() : tailIndex + 1 );
 
-                xbootIndex = retval.lastIndexOf( "-Xbootclasspath" );
+                    retval = head + tail;
+
+                    xbootIndex = retval.lastIndexOf( "-Xbootclasspath" );
+                }
+
+                retval = retval + " " + xbootClasspath;
             }
-
-            retval = retval+ " " + xbootClasspath;
         }
 
         return retval;

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/util/PingThread.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/util/PingThread.java
@@ -89,7 +89,7 @@ public class PingThread {
 				int code = ((HttpURLConnection)conn).getResponseCode();
 
 				// ping worked - server is up
-				if (!stop && code == 200) {
+				if (!stop && code != 404) {
 					Thread.sleep(200);
 					behaviour.setServerStarted();
 					stop = true;


### PR DESCRIPTION
fix stop error
and another case was found:
if we start a fresh dxp and goto localhost:8080 , it will return http 302  for licence requesting. So I change the
code == 200 to code != 404