### PR TITLE
IDE-3030 fix blade.cli downloading bug

### DIFF
--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/BladeCLI.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/modules/BladeCLI.java
@@ -203,7 +203,7 @@ public class BladeCLI
                 Version cliJarVersion = new Version( cliJarJar.getVersion() );
                 Version localCopyVersion = new Version( localJar.getVersion() );
 
-                if( cliJarVersion.compareTo( localCopyVersion ) > 0 )
+                if( cliJarVersion.compareTo( localCopyVersion ) >= 0 )
                 {
                     cachedBladeCLIPath = new Path( cliJar.getCanonicalPath() );
                 }


### PR DESCRIPTION
In BladeCLI.java
if we make it just > and  if our local jar version just equals with remote , and it will use local jar.
and in blade-cache-xxx.properties , it would be localjar=com.liferay.blade.cli.jar
when go into shouldUpdate method,  it will check the existing in repo cache and it will never find it , and will getLatestRemoteBladeCLIJar again and again.