### PR TITLE
IDE-3055 make deploy internal logic clear

### DIFF
--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/ILiferayMavenConstants.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/ILiferayMavenConstants.java
@@ -52,6 +52,8 @@ public interface ILiferayMavenConstants
 
     String LIFERAY_MAVEN_PLUGIN_KEY = _LIFERAY_MAVEN_PLUGINS_GROUP_ID + ":" + LIFERAY_MAVEN_PLUGIN; //$NON-NLS-1$
 
+    String LIFERAY_THEME_BUILDER_PLUGIN_KEY = "com.liferay:com.liferay.portal.tools.theme.builder";
+
     String M2E_LIFERAY_FOLDER = "m2e-liferay";  //$NON-NLS-1$
 
     String MAVEN_BUNDLE_PLUGIN_KEY = "org.apache.felix:maven-bundle-plugin";

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenProjectConfigurator.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenProjectConfigurator.java
@@ -210,7 +210,6 @@ public class LiferayMavenProjectConfigurator extends AbstractProjectConfigurator
         final IFile pomFile = project.getFile( IMavenConstants.POM_FILE_NAME );
         final IFacetedProject facetedProject = ProjectFacetsManager.create( project, false, monitor );
 
-
         removeLiferayMavenMarkers( project );
 
         monitor.worked( 25 );
@@ -353,9 +352,10 @@ public class LiferayMavenProjectConfigurator extends AbstractProjectConfigurator
 
     private boolean shouldAddLiferayNature( MavenProject mavenProject, IFacetedProject facetedProject )
     {
+        // TODO need to add more condition after adding jsf maven war project
         return mavenProject.getPlugin( ILiferayMavenConstants.BND_MAVEN_PLUGIN_KEY ) != null ||
-                mavenProject.getPlugin( ILiferayMavenConstants.MAVEN_BUNDLE_PLUGIN_KEY ) != null ||
-                getLiferayProjectFacet( facetedProject ) != null;
+            mavenProject.getPlugin( ILiferayMavenConstants.MAVEN_BUNDLE_PLUGIN_KEY ) != null ||
+            mavenProject.getPlugin( ILiferayMavenConstants.LIFERAY_THEME_BUILDER_PLUGIN_KEY ) != null;
     }
 
     public static IPath getThemeTargetFolder( MavenProject mavenProject, IProject project )

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/BundleFactoryDelegate.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/BundleFactoryDelegate.java
@@ -14,7 +14,6 @@
  *******************************************************************************/
 package com.liferay.ide.project.core;
 
-import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.project.core.util.ProjectUtil;
 
 import java.util.HashMap;
@@ -52,7 +51,7 @@ public class BundleFactoryDelegate extends ProjectModuleFactoryDelegate
     {
         IModule[] retval = new IModule[0];
 
-        if( ProjectUtil.isBundleProject( project ) )
+        if( ProjectUtil.is7xServerDeployableProject( project ) )
         {
             retval = new IModule[] { createSimpleModule( project ) };
         }

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/PluginsSDKBundleProject.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/PluginsSDKBundleProject.java
@@ -40,7 +40,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Status;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -156,7 +155,7 @@ public class PluginsSDKBundleProject extends FlexibleProject implements IWebProj
         return retval;
     }
 
-    protected SDK getSDK()
+    public SDK getSDK()
     {
         SDK retval = null;
 

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/util/ProjectUtil.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/util/ProjectUtil.java
@@ -16,6 +16,7 @@
 package com.liferay.ide.project.core.util;
 
 import com.liferay.ide.core.IBundleProject;
+import com.liferay.ide.core.ILiferayConstants;
 import com.liferay.ide.core.ILiferayProject;
 import com.liferay.ide.core.IWebProject;
 import com.liferay.ide.core.LiferayCore;
@@ -25,6 +26,7 @@ import com.liferay.ide.core.util.PropertiesUtil;
 import com.liferay.ide.core.util.StringPool;
 import com.liferay.ide.project.core.IPortletFramework;
 import com.liferay.ide.project.core.PluginClasspathContainerInitializer;
+import com.liferay.ide.project.core.PluginsSDKBundleProject;
 import com.liferay.ide.project.core.ProjectCore;
 import com.liferay.ide.project.core.ProjectRecord;
 import com.liferay.ide.project.core.SDKClasspathContainer;
@@ -100,6 +102,7 @@ import org.eclipse.wst.common.project.facet.core.internal.FacetedProjectWorkingC
 import org.eclipse.wst.common.project.facet.core.runtime.IRuntime;
 import org.eclipse.wst.common.project.facet.core.runtime.internal.BridgedRuntime;
 import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
 
 /**
  * @author Gregory Amerson
@@ -805,11 +808,48 @@ public class ProjectUtil
         return project;
     }
 
-    public static boolean isBundleProject( IProject project )
+    public static boolean is7xServerDeployableProject( IProject project )
     {
         final ILiferayProject liferayProject = LiferayCore.create( project );
 
-        return liferayProject instanceof IBundleProject;
+        if( liferayProject instanceof IBundleProject )
+        {
+            if( liferayProject instanceof PluginsSDKBundleProject )
+            {
+                PluginsSDKBundleProject sdkProject = (PluginsSDKBundleProject) liferayProject;
+
+                SDK sdk = sdkProject.getSDK();
+
+                if( sdk != null )
+                {
+                    Version version = new Version( sdk.getVersion() );
+                    Version sdk70 = ILiferayConstants.V700;
+                    // sdk 7.x proejct
+                    if( CoreUtil.compareVersions( version, sdk70 ) >= 0 )
+                    {
+                        return true;
+                    }
+                    // sdk 6.x project
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            // not sdk project
+            else
+            {
+                return true;
+            }
+        }
+        else
+        {
+            return false;
+        }
     }
 
     private static boolean isLiferayRuntimePluginClassPath(IClasspathEntry entry)

--- a/tools/plugins/com.liferay.ide.server.ui/plugin.xml
+++ b/tools/plugins/com.liferay.ide.server.ui/plugin.xml
@@ -533,7 +533,8 @@
          point="org.eclipse.wst.server.core.moduleArtifactAdapters">
       <moduleArtifactAdapter
             class="com.liferay.ide.server.ui.portal.BundleModuleArtifactAdapterDelegate"
-            id="com.liferay.ide.server.ui.bundleModuleArtifactAdapter">
+            id="com.liferay.ide.server.ui.bundleModuleArtifactAdapter"
+            priority="1">
          <enablement>
            <with variable="selection">
              <adapt type="org.eclipse.core.resources.IProject">

--- a/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/portal/BundleModuleArtifactAdapterDelegate.java
+++ b/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/portal/BundleModuleArtifactAdapterDelegate.java
@@ -14,7 +14,6 @@
  *******************************************************************************/
 package com.liferay.ide.server.ui.portal;
 
-import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.project.core.util.ProjectUtil;
 
 import org.eclipse.core.resources.IProject;
@@ -79,7 +78,7 @@ public class BundleModuleArtifactAdapterDelegate extends ModuleArtifactAdapterDe
 
        if( project != null )
        {
-            if( ProjectUtil.isBundleProject( project ) )
+            if( ProjectUtil.is7xServerDeployableProject( project ) )
             {
                 return new WebResource( getModule( project ), project.getProjectRelativePath() );
             }


### PR DESCRIPTION
changes:
1. don't add liferay nature to 6.2 maven project and add it to 7.0 maven theme project see LiferayMavenProjectConfigurator.shouldAddLiferayNature()
2. prevent deploying 6.2 sdk project into 7.0 server
3. make BundleModuleArtifactAdapterDelegate priority higher so wtp.server.core will get it first and it will adapt 7.0 maven theme project(FacetedMavenBundleProject) before jst.web ModuleArtifactAdapter.