### PR TITLE
IDE-3070 fix Hotdeploy doesn't work when making some changes in jsp

### DIFF
--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/MavenBundlePluginProject.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/MavenBundlePluginProject.java
@@ -108,9 +108,9 @@ public class MavenBundlePluginProject extends LiferayMavenProject implements IBu
         {
             this.getProject().build( IncrementalProjectBuilder.CLEAN_BUILD, monitor );
             this.getProject().build( IncrementalProjectBuilder.FULL_BUILD, monitor );
-
-            mavenProjectBuilder.execJarMojo( projectFacade, monitor );
         }
+
+        mavenProjectBuilder.execJarMojo( projectFacade, monitor );
 
         final MavenProject mavenProject = projectFacade.getMavenProject( monitor );
 


### PR DESCRIPTION
Hey Greg, I find that if users not choose Build Automatically, it has no problem.
Reasons for not work:
Because the user choose Project->Build Automatically in Eclipse, it will not excute 
if( cleanBuild || !isAutoBuild() )
{ this.getProject().build( IncrementalProjectBuilder.CLEAN_BUILD, monitor ); this.getProject().build( IncrementalProjectBuilder.FULL_BUILD, monitor ); mavenProjectBuilder.execJarMojo( projectFacade, monitor ); }
So I moved the execJarMojo( projectFacade, monitor ) out of if, and it works.