### PR TITLE
IDE-3050 extract createBundleSupervisor method and read custom jmx an…

### DIFF
--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/BundlePublishOperation.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/BundlePublishOperation.java
@@ -14,9 +14,7 @@
  *******************************************************************************/
 package com.liferay.ide.server.core.portal;
 
-import aQute.remote.api.Agent;
-
-import com.liferay.ide.server.core.ILiferayServerBehavior;
+import com.liferay.ide.server.util.ServerUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,13 +88,7 @@ public class BundlePublishOperation extends PublishOperation
 
     protected BundleSupervisor createBundleSupervisor() throws Exception
     {
-        BundleSupervisor bundleSupervisor = new BundleSupervisor( portalRuntime.getPortalBundle().getJmxRemotePort() );
-
-        int agentPort = server.getAttribute( ILiferayServerBehavior.AGENT_PORT, Agent.DEFAULT_PORT );
-
-        bundleSupervisor.connect( server.getHost(), agentPort );
-
-        return bundleSupervisor;
+        return ServerUtil.createBundleSupervisor( portalRuntime, server );
     }
 
 }

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerBehavior.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerBehavior.java
@@ -24,6 +24,7 @@ import com.liferay.ide.core.util.FileUtil;
 import com.liferay.ide.server.core.ILiferayServerBehavior;
 import com.liferay.ide.server.core.LiferayServerCore;
 import com.liferay.ide.server.util.PingThread;
+import com.liferay.ide.server.util.ServerUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -887,14 +888,7 @@ public class PortalServerBehavior extends ServerBehaviourDelegate
 
     public BundleSupervisor createBundleSupervisor() throws Exception
     {
-        BundleSupervisor bundleSupervisor =
-            new BundleSupervisor( getPortalRuntime().getPortalBundle().getJmxRemotePort() );
-
-        int agentPort = getServer().getAttribute( AGENT_PORT, Agent.DEFAULT_PORT );
-
-        bundleSupervisor.connect( getServer().getHost(), agentPort );
-
-        return bundleSupervisor;
+        return ServerUtil.createBundleSupervisor( getPortalRuntime(), getServer() );
     }
 
 }


### PR DESCRIPTION
…d bnd agent port

hey Greg,  I've change the code according to your jmx deployer , and the code is for reading custom aQute agent port and jmx port in server launch configuration vm args .
Default value is:
-DaQute.agent.server.port=29998
-Dcom.sun.management.jmxremote.port=8099

You can change the port and start the server , when started , if you deploy , it will block cause it can't connect to the right port.
