### PR TITLE
IDE-3222 fix Kaleo workflow can't deploy to liferay DXP bundle

### DIFF
--- a/enterprise/plugins/com.liferay.ide.kaleo.core/src/com/liferay/ide/kaleo/core/KaleoCore.java
+++ b/enterprise/plugins/com.liferay.ide.kaleo.core/src/com/liferay/ide/kaleo/core/KaleoCore.java
@@ -163,7 +163,7 @@ public class KaleoCore extends Plugin
     public static void updateKaleoConnectionSettings( ILiferayServer server, IKaleoConnection connection )
     {
         connection.setHost( server.getHost() );
-        //connection.setHttpPort( server.getHttpPort() );
+        connection.setHttpPort( server.getHttpPort() );
         connection.setPortalHtmlUrl( server.getPortalHomeUrl() );
         connection.setPortalContextPath( "/" );
         connection.setUsername( server.getUsername() );

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/ILiferayServer.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/ILiferayServer.java
@@ -49,6 +49,8 @@ public interface ILiferayServer
 
     String getUsername();
 
+    String getHttpPort();
+
     String getId();
 
     String getHost();

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerDelegate.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerDelegate.java
@@ -78,6 +78,13 @@ public class PortalServerDelegate extends ServerDelegate implements PortalServer
     }
 
     @Override
+    public String getHttpPort()
+    {
+        // TODO IDE-1955
+        return "8080";
+    }
+
+    @Override
     public IModule[] getChildModules( IModule[] module )
     {
         IModule[] retval = null;

--- a/tools/plugins/com.liferay.ide.server.tomcat.core/src/com/liferay/ide/server/tomcat/core/LiferayTomcatServer.java
+++ b/tools/plugins/com.liferay.ide.server.tomcat.core/src/com/liferay/ide/server/tomcat/core/LiferayTomcatServer.java
@@ -126,6 +126,19 @@ public class LiferayTomcatServer extends TomcatServer
     }
 
     @Override
+    public String getHttpPort()
+    {
+        try
+        {
+            return String.valueOf( getTomcatConfiguration().getMainPort().getPort() );
+        }
+        catch( CoreException e )
+        {
+            return null;
+        }
+    }
+
+    @Override
     public URL getPortalHomeUrl()
     {
         try


### PR DESCRIPTION
Hey Greg, 
I just revert IDE-1955 back. 
IDE-1955 remove unused getHttpPort method in ILiferayServer 
Since we move Kaleo back, I add it back.
And I will redo IDE-1955 later.