### PR TITLE
IDE-3245  Default workspace prompt location for Studio should not be …

### DIFF
--- a/build/com.liferay.ide-repository/studio.product
+++ b/build/com.liferay.ide-repository/studio.product
@@ -176,6 +176,7 @@ to distribution rights of the Software.
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.update.configurator" autoStart="true" startLevel="4" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
    </configurations>
 
 </product>


### PR DESCRIPTION
…inside of .app folder