### PR TITLE
Should not allow redeploy multiple projects same time

### DIFF
--- a/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/action/RedeployAction.java
+++ b/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/action/RedeployAction.java
@@ -105,7 +105,7 @@ public class RedeployAction extends AbstractServerRunningAction
         {
             final List<ModuleServer> newModules = new ArrayList<>();
 
-            if( selection instanceof IStructuredSelection )
+            if( selection instanceof IStructuredSelection && ( (IStructuredSelection) selection ).size() == 1 )
             {
                 final IStructuredSelection obj = (IStructuredSelection) selection;
                 final Iterator selectionIterator = obj.iterator();


### PR DESCRIPTION
As we tested, it very often happens the unstable errors if we redeploy multiple projects at same time, the errors maybe happen in gradle end, portal end, or resource locked, it's hard to detect where is problem root, but there is no problem if redeploy one project at once time, so I think we no need provide this