### PR TITLE
IDE-3338 update bundle url to liferay ga4

### DIFF
--- a/maven/tests/com.liferay.ide.maven.core.tests/src/com/liferay/ide/maven/core/tests/MavenModuleFragmentProjectTests.java
+++ b/maven/tests/com.liferay.ide.maven.core.tests/src/com/liferay/ide/maven/core/tests/MavenModuleFragmentProjectTests.java
@@ -46,13 +46,13 @@ public class MavenModuleFragmentProjectTests extends ServerCoreBase
     @Override
     protected IPath getLiferayRuntimeDir()
     {
-        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga3/tomcat-8.0.32" );
+        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga4/tomcat-8.0.32" );
     }
 
     @Override
     protected IPath getLiferayRuntimeZip()
     {
-        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip" );
+        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip" );
     }
 
     @Override

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/workspace/BaseLiferayWorkspaceOp.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/workspace/BaseLiferayWorkspaceOp.java
@@ -32,7 +32,7 @@ import org.eclipse.sapphire.modeling.annotations.Service;
 public interface BaseLiferayWorkspaceOp extends ExecutableElement
 {
     public static final String defaultBundleUrl =
-                    "https://cdn.lfrs.sl/releases.liferay.com/portal/7.0.2-ga3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip";
+                    "https://cdn.lfrs.sl/releases.liferay.com/portal/7.0.3-ga4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip";
 
     ElementType TYPE = new ElementType( BaseLiferayWorkspaceOp.class );
 

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/upgrade/animated/LiferayUpgradeDataModel.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/upgrade/animated/LiferayUpgradeDataModel.java
@@ -31,7 +31,7 @@ import org.eclipse.sapphire.modeling.annotations.Service;
 public interface LiferayUpgradeDataModel extends Element
 {
 
-    String DEFAULT_BUNDLE_URL = "https://cdn.lfrs.sl/releases.liferay.com/portal/7.0.2-ga3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip";
+    String DEFAULT_BUNDLE_URL = "https://cdn.lfrs.sl/releases.liferay.com/portal/7.0.3-ga4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip";
 
     ElementType TYPE = new ElementType( LiferayUpgradeDataModel.class );
 

--- a/tools/tests/com.liferay.ide.gradle.core.tests/projects/liferay-workspace-ee/gradle.properties
+++ b/tools/tests/com.liferay.ide.gradle.core.tests/projects/liferay-workspace-ee/gradle.properties
@@ -1,4 +1,4 @@
-#liferay.workspace.bundle.url=https://sourceforge.net/projects/lportal/files/Liferay Portal/7.0.2 GA3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip
+#liferay.workspace.bundle.url=https://cdn.lfrs.sl/releases.liferay.com/portal/7.0.3-ga4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip
 #liferay.workspace.environment=local
 #liferay.workspace.home.dir=bundles
 #liferay.workspace.modules.default.repository.enabled=false

--- a/tools/tests/com.liferay.ide.gradle.core.tests/projects/testWorkspace/gradle.properties
+++ b/tools/tests/com.liferay.ide.gradle.core.tests/projects/testWorkspace/gradle.properties
@@ -1,4 +1,4 @@
-#liferay.workspace.bundle.url=https://cdn.lfrs.sl/releases.liferay.com/portal/7.0.2-ga3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip
+#liferay.workspace.bundle.url=https://cdn.lfrs.sl/releases.liferay.com/portal/7.0.3-ga4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip
 #liferay.workspace.environment=local
 #liferay.workspace.home.dir=bundles
 #liferay.workspace.modules.default.repository.enabled=false

--- a/tools/tests/com.liferay.ide.project.core.tests/src/com/liferay/ide/project/core/tests/NewLiferayPluginProjectOp701Tests.java
+++ b/tools/tests/com.liferay.ide.project.core.tests/src/com/liferay/ide/project/core/tests/NewLiferayPluginProjectOp701Tests.java
@@ -64,12 +64,12 @@ public class NewLiferayPluginProjectOp701Tests extends NewLiferayPluginProjectOp
 
     protected IPath getLiferayRuntimeDir()
     {
-        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga3/tomcat-8.0.32" );
+        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga4/tomcat-8.0.32" );
     }
 
     protected IPath getLiferayRuntimeZip()
     {
-        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip" );
+        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip" );
     }
 
     public String getRuntimeVersion()

--- a/tools/tests/com.liferay.ide.project.core.tests/src/com/liferay/ide/project/core/tests/NewLiferayPluginProjectOp7sp3Tests.java
+++ b/tools/tests/com.liferay.ide.project.core.tests/src/com/liferay/ide/project/core/tests/NewLiferayPluginProjectOp7sp3Tests.java
@@ -64,12 +64,12 @@ public class NewLiferayPluginProjectOp7sp3Tests extends NewLiferayPluginProjectO
 
     protected IPath getLiferayRuntimeDir()
     {
-        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga3/tomcat-8.0.32" );
+        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga4/tomcat-8.0.32" );
     }
 
     protected IPath getLiferayRuntimeZip()
     {
-        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip" );
+        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip" );
     }
 
     public String getRuntimeVersion()

--- a/tools/tests/com.liferay.ide.server.core.tests/src/com/liferay/ide/server/core/tests/PortalBundleTests.java
+++ b/tools/tests/com.liferay.ide.server.core.tests/src/com/liferay/ide/server/core/tests/PortalBundleTests.java
@@ -38,13 +38,13 @@ public class PortalBundleTests extends ServerCoreBase
     @Override
     protected IPath getLiferayRuntimeDir()
     {
-        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga3/tomcat-8.0.32" );
+        return ProjectCore.getDefault().getStateLocation().append( "liferay-ce-portal-7.0-ga4/tomcat-8.0.32" );
     }
 
     @Override
     protected IPath getLiferayRuntimeZip()
     {
-        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip" );
+        return getLiferayBundlesPath().append( "liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip" );
     }
 
     @Override


### PR DESCRIPTION
@gamerson Hey greg, it failed the jinkens test because of /home/jenkins/resources/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip didn't exist.  It would be ok when we put a ga4 bundle in that directory. 