### PR TITLE
Make the error massage more readable when it is unable to fetch the portal bundle from sdk

### DIFF
--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/PluginsSDKProjectProvider.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/PluginsSDKProjectProvider.java
@@ -12,6 +12,7 @@
  * details.
  *
  *******************************************************************************/
+
 package com.liferay.ide.project.core;
 
 import com.liferay.ide.core.AbstractLiferayProjectProvider;
@@ -29,6 +30,7 @@ import com.liferay.ide.sdk.core.ISDKConstants;
 import com.liferay.ide.sdk.core.SDK;
 import com.liferay.ide.sdk.core.SDKUtil;
 import com.liferay.ide.server.core.ILiferayRuntime;
+import com.liferay.ide.server.core.portal.EmptyPortalBundle;
 import com.liferay.ide.server.core.portal.PortalBundle;
 import com.liferay.ide.server.util.ServerUtil;
 
@@ -58,13 +60,13 @@ import org.eclipse.sapphire.platform.PathBridge;
 import org.eclipse.wst.server.core.IRuntime;
 import org.osgi.framework.Version;
 
-
 /**
  * @author Gregory Amerson
  * @author Simon Jiang
  * @author Terry Jia
  */
-public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider implements NewLiferayProjectProvider<NewLiferayPluginProjectOp>
+public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider
+    implements NewLiferayProjectProvider<NewLiferayPluginProjectOp>
 {
 
     public PluginsSDKProjectProvider()
@@ -81,7 +83,7 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
 
         final IStatus status = portletFramework.postProjectCreated( newProject, frameworkName, portletName, monitor );
 
-        if( ! status.isOK() )
+        if( !status.isOK() )
         {
             throw new CoreException( status );
         }
@@ -125,14 +127,13 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
                 {
                     final IJavaProject javaProject = JavaCore.create( project );
 
-                    final boolean hasNewSdk =
-                        ClasspathUtil.hasNewLiferaySDKContainer( javaProject.getRawClasspath() );
+                    final boolean hasNewSdk = ClasspathUtil.hasNewLiferaySDKContainer( javaProject.getRawClasspath() );
 
                     if( hasNewSdk )
                     {
                         final PortalBundle portalBundle = ServerUtil.getPortalBundle( project );
 
-                        if( portalBundle != null )
+                        if( !( portalBundle instanceof EmptyPortalBundle ) )
                         {
                             retval = new PluginsSDKBundleProject( project, portalBundle );
                         }
@@ -174,10 +175,12 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
     }
 
     private void serviceBuilderProjectCreated(
-        NewLiferayPluginProjectOp op, String version, IProject newProject, IProgressMonitor monitor ) throws CoreException
+        NewLiferayPluginProjectOp op, String version, IProject newProject, IProgressMonitor monitor )
+        throws CoreException
     {
         // create a default service.xml file in the project
-        final IFile serviceXmlFile = newProject.getFile( ISDKConstants.DEFAULT_DOCROOT_FOLDER + "/WEB-INF/service.xml" );
+        final IFile serviceXmlFile =
+            newProject.getFile( ISDKConstants.DEFAULT_DOCROOT_FOLDER + "/WEB-INF/service.xml" );
 
         String descriptorVersion = null;
 
@@ -185,7 +188,7 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
         {
             Version portalVersion = new Version( version );
 
-            descriptorVersion = portalVersion.getMajor() + "." + portalVersion.getMinor() + ".0";  //$NON-NLS-1$//$NON-NLS-2$
+            descriptorVersion = portalVersion.getMajor() + "." + portalVersion.getMinor() + ".0"; //$NON-NLS-1$//$NON-NLS-2$
         }
         catch( Exception e )
         {
@@ -194,7 +197,8 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
         }
 
         WizardUtil.createDefaultServiceBuilderFile(
-            serviceXmlFile, descriptorVersion, true, "com.liferay.sample", "SAMPLE", System.getProperty( "user.name" ), monitor );
+            serviceXmlFile, descriptorVersion, true, "com.liferay.sample", "SAMPLE", System.getProperty( "user.name" ),
+            monitor );
     }
 
     private void themeProjectCreated( IProject newProject ) throws CoreException
@@ -211,10 +215,10 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
     {
         IStatus retval = Status.OK_STATUS;
 
-        if( path.append(".project").toFile().exists() ) //$NON-NLS-1$
+        if( path.append( ".project" ).toFile().exists() ) //$NON-NLS-1$
         {
             retval = ProjectCore.createErrorStatus( "\"" + path + //$NON-NLS-1$
-                    "\" is not valid because a project already exists at that location." ); //$NON-NLS-1$
+                "\" is not valid because a project already exists at that location." ); //$NON-NLS-1$
         }
         else
         {
@@ -223,7 +227,7 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
             if( pathFile.exists() && pathFile.isDirectory() && pathFile.listFiles().length > 0 )
             {
                 retval = ProjectCore.createErrorStatus( "\"" + path + //$NON-NLS-1$
-                        "\" is not valid because it already contains files." ); //$NON-NLS-1$
+                    "\" is not valid because it already contains files." ); //$NON-NLS-1$
             }
         }
 
@@ -287,7 +291,8 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
 
         if( originalProjectName.endsWith( pluginTypeSuffix ) )
         {
-            fixedProjectName = originalProjectName.substring( 0, originalProjectName.length() - pluginTypeSuffix.length() );
+            fixedProjectName =
+                originalProjectName.substring( 0, originalProjectName.length() - pluginTypeSuffix.length() );
         }
 
         final String projectName = fixedProjectName;
@@ -310,107 +315,101 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
 
         switch( pluginType )
         {
-            case servicebuilder:
-                op.setPortletFramework( "mvc" );
-            case portlet:
-                final String frameworkName = NewLiferayPluginProjectOpMethods.getFrameworkName( op );
+        case servicebuilder:
+            op.setPortletFramework( "mvc" );
+        case portlet:
+            final String frameworkName = NewLiferayPluginProjectOpMethods.getFrameworkName( op );
 
-                workingDir = sdk.getLocation().append( ISDKConstants.PORTLET_PLUGIN_PROJECT_FOLDER ).toOSString();
+            workingDir = sdk.getLocation().append( ISDKConstants.PORTLET_PLUGIN_PROJECT_FOLDER ).toOSString();
 
-                if( hasGradleTools )
-                {
-                    arguments.add( frameworkName );
+            if( hasGradleTools )
+            {
+                arguments.add( frameworkName );
 
-                    sdk.createNewProject( projectName, arguments, "portlet", workingDir, monitor );
-                }
-                else
-                {
-                    newSDKProjectPath =
-                        sdk.createNewPortletProject(
-                            projectName, displayName, frameworkName, separateJRE, workingDir,
-                            null, monitor );
-                }
+                sdk.createNewProject( projectName, arguments, "portlet", workingDir, monitor );
+            }
+            else
+            {
+                newSDKProjectPath = sdk.createNewPortletProject(
+                    projectName, displayName, frameworkName, separateJRE, workingDir, null, monitor );
+            }
 
-                break;
+            break;
 
-            case hook:
-                workingDir = sdk.getLocation().append( ISDKConstants.HOOK_PLUGIN_PROJECT_FOLDER ).toOSString();
+        case hook:
+            workingDir = sdk.getLocation().append( ISDKConstants.HOOK_PLUGIN_PROJECT_FOLDER ).toOSString();
 
-                if( hasGradleTools )
-                {
-                    sdk.createNewProject( projectName, arguments, "hook", workingDir, monitor );
-                }
-                else
-                {
-                    newSDKProjectPath =
-                        sdk.createNewHookProject(
-                            projectName, displayName, separateJRE, workingDir, null, monitor );
-                }
+            if( hasGradleTools )
+            {
+                sdk.createNewProject( projectName, arguments, "hook", workingDir, monitor );
+            }
+            else
+            {
+                newSDKProjectPath =
+                    sdk.createNewHookProject( projectName, displayName, separateJRE, workingDir, null, monitor );
+            }
 
-                break;
+            break;
 
-            case ext:
-                workingDir = sdk.getLocation().append( ISDKConstants.EXT_PLUGIN_PROJECT_FOLDER ).toOSString();
+        case ext:
+            workingDir = sdk.getLocation().append( ISDKConstants.EXT_PLUGIN_PROJECT_FOLDER ).toOSString();
 
-                if( hasGradleTools )
-                {
-                    sdk.createNewProject( projectName, arguments, "ext", workingDir, monitor );
-                }
-                else
-                {
-                    newSDKProjectPath =
-                        sdk.createNewExtProject(
-                            projectName, displayName, separateJRE, workingDir, null, monitor );
-                }
+            if( hasGradleTools )
+            {
+                sdk.createNewProject( projectName, arguments, "ext", workingDir, monitor );
+            }
+            else
+            {
+                newSDKProjectPath =
+                    sdk.createNewExtProject( projectName, displayName, separateJRE, workingDir, null, monitor );
+            }
 
-                break;
+            break;
 
-            case layouttpl:
-                workingDir = sdk.getLocation().append( ISDKConstants.LAYOUTTPL_PLUGIN_PROJECT_FOLDER ).toOSString();
+        case layouttpl:
+            workingDir = sdk.getLocation().append( ISDKConstants.LAYOUTTPL_PLUGIN_PROJECT_FOLDER ).toOSString();
 
-                if( hasGradleTools )
-                {
-                    sdk.createNewProject( projectName, arguments, "layouttpl", workingDir, monitor );
-                }
-                else
-                {
-                    newSDKProjectPath =
-                        sdk.createNewLayoutTplProject(
-                            projectName, displayName, separateJRE, workingDir, null, monitor );
-                }
+            if( hasGradleTools )
+            {
+                sdk.createNewProject( projectName, arguments, "layouttpl", workingDir, monitor );
+            }
+            else
+            {
+                newSDKProjectPath =
+                    sdk.createNewLayoutTplProject( projectName, displayName, separateJRE, workingDir, null, monitor );
+            }
 
-                break;
+            break;
 
-            case theme:
-                workingDir = sdk.getLocation().append( ISDKConstants.THEME_PLUGIN_PROJECT_FOLDER ).toOSString();
+        case theme:
+            workingDir = sdk.getLocation().append( ISDKConstants.THEME_PLUGIN_PROJECT_FOLDER ).toOSString();
 
-                if( hasGradleTools )
-                {
-                    sdk.createNewProject( projectName, arguments, "theme", workingDir, monitor );
-                }
-                else
-                {
-                    newSDKProjectPath =
-                        sdk.createNewThemeProject( projectName, displayName, separateJRE, workingDir, null, monitor );
-                }
+            if( hasGradleTools )
+            {
+                sdk.createNewProject( projectName, arguments, "theme", workingDir, monitor );
+            }
+            else
+            {
+                newSDKProjectPath =
+                    sdk.createNewThemeProject( projectName, displayName, separateJRE, workingDir, null, monitor );
+            }
 
-                break;
+            break;
 
-            case web:
-                workingDir = sdk.getLocation().append( ISDKConstants.WEB_PLUGIN_PROJECT_FOLDER ).toOSString();
+        case web:
+            workingDir = sdk.getLocation().append( ISDKConstants.WEB_PLUGIN_PROJECT_FOLDER ).toOSString();
 
-                if( hasGradleTools )
-                {
-                    sdk.createNewProject( projectName, arguments, "web", workingDir, monitor );
-                }
-                else
-                {
-                    newSDKProjectPath =
-                        sdk.createNewWebProject(
-                            projectName, displayName, separateJRE, workingDir, null, monitor );
-                }
+            if( hasGradleTools )
+            {
+                sdk.createNewProject( projectName, arguments, "web", workingDir, monitor );
+            }
+            else
+            {
+                newSDKProjectPath =
+                    sdk.createNewWebProject( projectName, displayName, separateJRE, workingDir, null, monitor );
+            }
 
-                break;
+            break;
         }
 
         NewLiferayPluginProjectOpMethods.updateLocation( op );
@@ -441,8 +440,7 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
 
         final ProjectRecord projectRecord = ProjectUtil.getProjectRecordForDir( projectLocation.toOSString() );
 
-        final IProject newProject =
-            ProjectImportUtil.importProject( projectRecord.getProjectLocation(), monitor, op );
+        final IProject newProject = ProjectImportUtil.importProject( projectRecord.getProjectLocation(), monitor, op );
 
         newProject.open( monitor );
 
@@ -455,25 +453,25 @@ public class PluginsSDKProjectProvider extends AbstractLiferayProjectProvider im
 
         switch( op.getPluginType().content() )
         {
-            case portlet:
+        case portlet:
 
-                portletProjectCreated( op, newProject, monitor );
+            portletProjectCreated( op, newProject, monitor );
 
-                break;
+            break;
 
-            case servicebuilder:
+        case servicebuilder:
 
-                PortalBundle bundle = ServerUtil.getPortalBundle( newProject );
-                serviceBuilderProjectCreated( op, bundle.getVersion(), newProject, monitor );
+            PortalBundle bundle = ServerUtil.getPortalBundle( newProject );
+            serviceBuilderProjectCreated( op, bundle.getVersion(), newProject, monitor );
 
-                break;
-            case theme:
+            break;
+        case theme:
 
-                themeProjectCreated( newProject );
+            themeProjectCreated( newProject );
 
-                break;
-            default:
-                break;
+            break;
+        default:
+            break;
         }
 
         return Status.OK_STATUS;

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/SDKClasspathContainerInitializer.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/SDKClasspathContainerInitializer.java
@@ -17,6 +17,7 @@ package com.liferay.ide.project.core;
 
 import com.liferay.ide.sdk.core.SDK;
 import com.liferay.ide.sdk.core.SDKUtil;
+import com.liferay.ide.server.core.portal.EmptyPortalBundle;
 import com.liferay.ide.server.core.portal.PortalBundle;
 import com.liferay.ide.server.util.ServerUtil;
 
@@ -37,6 +38,7 @@ import org.eclipse.jst.common.jdt.internal.classpath.ClasspathDecorationsManager
 @SuppressWarnings( "restriction" )
 public class SDKClasspathContainerInitializer extends ClasspathContainerInitializer
 {
+
     protected static final ClasspathDecorationsManager cpDecorations = SDKClasspathContainer.getDecorationsManager();
 
     @Override
@@ -51,7 +53,7 @@ public class SDKClasspathContainerInitializer extends ClasspathContainerInitiali
 
         SDK sdk = SDKUtil.getSDKFromProjectDir( project.getProject().getLocation().toFile() );
 
-        if ( sdk != null )
+        if( sdk != null )
         {
             dependencyJarPaths = sdk.getDependencyJarPaths();
         }
@@ -72,12 +74,11 @@ public class SDKClasspathContainerInitializer extends ClasspathContainerInitiali
             throw new CoreException( ProjectCore.createErrorStatus( msg + SDKClasspathContainer.ID ) );
         }
 
-        PortalBundle bundle = ServerUtil.getPortalBundle(project.getProject());
+        PortalBundle bundle = ServerUtil.getPortalBundle( project.getProject() );
 
-        if ( bundle == null )
+        if( bundle instanceof EmptyPortalBundle )
         {
-            final String msg = "Invalid sdk properties setting.";
-            throw new CoreException( ProjectCore.createErrorStatus( msg ) );
+            throw new CoreException( ProjectCore.createErrorStatus( ( (EmptyPortalBundle) bundle ).getMsg() ) );
         }
 
         IPath globalDir = bundle.getAppServerLibGlobalDir();
@@ -95,10 +96,9 @@ public class SDKClasspathContainerInitializer extends ClasspathContainerInitiali
             return;
         }
 
-        classpathContainer =
-            new SDKClasspathContainer(
-                containerPath, project, portalDir, null, null, globalDir, bundleDir, bundleDependencyJars,
-                sdkDependencyJarPaths );
+        classpathContainer = new SDKClasspathContainer(
+            containerPath, project, portalDir, null, null, globalDir, bundleDir, bundleDependencyJars,
+            sdkDependencyJarPaths );
 
         JavaCore.setClasspathContainer(
             containerPath, new IJavaProject[] { project }, new IClasspathContainer[] { classpathContainer }, null );
@@ -145,7 +145,7 @@ public class SDKClasspathContainerInitializer extends ClasspathContainerInitiali
         IPath bundleDir = null;
         IPath[] bundleDependencyJarPaths = null;
 
-        PortalBundle bundle = ServerUtil.getPortalBundle(project.getProject());
+        PortalBundle bundle = ServerUtil.getPortalBundle( project.getProject() );
 
         boolean containerChanged = true;
 
@@ -158,15 +158,15 @@ public class SDKClasspathContainerInitializer extends ClasspathContainerInitiali
             sourceLocation = ( (SDKClasspathContainer) containerSuggestion ).getSourceLocation();
             bundleDependencyJarPaths = ( (SDKClasspathContainer) containerSuggestion ).getBundleLibDependencyPath();
 
-            if ( bundle != null && bundle.getAppServerPortalDir().equals( portalDir ) )
+            if( !( bundle instanceof EmptyPortalBundle ) && bundle.getAppServerPortalDir().equals( portalDir ) )
             {
                 containerChanged = false;
             }
         }
 
-        if ( containerChanged == true)
+        if( containerChanged == true )
         {
-            if ( bundle == null )
+            if( bundle == null )
             {
                 return;
             }
@@ -180,10 +180,9 @@ public class SDKClasspathContainerInitializer extends ClasspathContainerInitiali
 
         if( portalDir != null && portalGlobalDir != null )
         {
-            IClasspathContainer newContainer =
-                new SDKClasspathContainer(
-                    containerPath, project, portalDir, javadocURL, sourceLocation, portalGlobalDir, bundleDir,
-                    bundleDependencyJarPaths, sdkDependencyPaths );
+            IClasspathContainer newContainer = new SDKClasspathContainer(
+                containerPath, project, portalDir, javadocURL, sourceLocation, portalGlobalDir, bundleDir,
+                bundleDependencyJarPaths, sdkDependencyPaths );
 
             JavaCore.setClasspathContainer(
                 containerPath, new IJavaProject[] { project }, new IClasspathContainer[] { newContainer }, null );

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/EmptyPortalBundle.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/EmptyPortalBundle.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liferay.ide.server.core.portal;
+
+import java.util.Properties;
+
+import org.eclipse.core.runtime.IPath;
+
+/**
+ * @author Terry Jia
+ */
+public class EmptyPortalBundle implements PortalBundle
+{
+
+    private final String msg;
+
+    public EmptyPortalBundle( String msg )
+    {
+        this.msg = msg;
+    }
+
+    @Override
+    public IPath getAppServerDeployDir()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath getAppServerDir()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath getAppServerLibGlobalDir()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath getAppServerPortalDir()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath getAutoDeployPath()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath[] getBundleDependencyJars()
+    {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return null;
+    }
+
+    @Override
+    public String[] getHookSupportedProperties()
+    {
+        return null;
+    }
+
+    @Override
+    public String getHttpPort()
+    {
+        return null;
+    }
+
+    @Override
+    public int getJmxRemotePort()
+    {
+        return 0;
+    }
+
+    @Override
+    public IPath getLiferayHome()
+    {
+        return null;
+    }
+
+    @Override
+    public String getMainClass()
+    {
+        return null;
+    }
+
+    public String getMsg()
+    {
+        return msg;
+    }
+
+    @Override
+    public IPath getModulesPath()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath getOSGiBundlesDir()
+    {
+        return null;
+    }
+
+    @Override
+    public Properties getPortletCategories()
+    {
+        return null;
+    }
+
+    @Override
+    public Properties getPortletEntryCategories()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath[] getRuntimeClasspath()
+    {
+        return null;
+    }
+
+    @Override
+    public String[] getRuntimeStartProgArgs()
+    {
+        return null;
+    }
+
+    @Override
+    public String[] getRuntimeStartVMArgs()
+    {
+        return null;
+    }
+
+    @Override
+    public String[] getRuntimeStopProgArgs()
+    {
+        return null;
+    }
+
+    @Override
+    public String[] getRuntimeStopVMArgs()
+    {
+        return null;
+    }
+
+    @Override
+    public String getType()
+    {
+        return null;
+    }
+
+    @Override
+    public IPath[] getUserLibs()
+    {
+        return null;
+    }
+
+    @Override
+    public String getVersion()
+    {
+        return null;
+    }
+
+    @Override
+    public void setHttpPort( String port )
+    {
+    }
+
+}

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/util/ServerUtil.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/util/ServerUtil.java
@@ -30,6 +30,7 @@ import com.liferay.ide.server.core.ILiferayRuntime;
 import com.liferay.ide.server.core.ILiferayServer;
 import com.liferay.ide.server.core.LiferayServerCore;
 import com.liferay.ide.server.core.portal.BundleSupervisor;
+import com.liferay.ide.server.core.portal.EmptyPortalBundle;
 import com.liferay.ide.server.core.portal.PortalBundle;
 import com.liferay.ide.server.core.portal.PortalBundleFactory;
 import com.liferay.ide.server.core.portal.PortalRuntime;
@@ -131,43 +132,15 @@ public class ServerUtil
         int jmxPort = portalRuntime.getPortalBundle().getJmxRemotePort();
 
         /*
-        try
-        {
-            String launchVmArguments = server.getLaunchConfiguration( true, null ).getWorkingCopy().getAttribute(
-                IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, "" );
-
-            Matcher aQutematcher = aQuteAgentPortPattern.matcher( launchVmArguments );
-            Matcher jmxMatcher = jmxRemotePortPattern.matcher( launchVmArguments );
-
-            String agentPortStr = null;
-
-            if( aQutematcher.find() )
-            {
-                agentPortStr = aQutematcher.group( 1 );
-            }
-
-            if( !CoreUtil.empty( agentPortStr ) )
-            {
-                aQuteAgentPort = Integer.parseInt( agentPortStr );
-            }
-
-            String jmxPortStr = null;
-
-            if( jmxMatcher.find() )
-            {
-                jmxPortStr = jmxMatcher.group( 1 );
-            }
-
-            if( !CoreUtil.empty( jmxPortStr ) )
-            {
-                jmxPort = Integer.parseInt( jmxPortStr );
-            }
-        }
-        catch( Exception e )
-        {
-            LiferayServerCore.logError( "can't get agent or jmx port from server launch configuration ", e );
-        }
-        */
+         * try { String launchVmArguments = server.getLaunchConfiguration( true, null ).getWorkingCopy().getAttribute(
+         * IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, "" ); Matcher aQutematcher =
+         * aQuteAgentPortPattern.matcher( launchVmArguments ); Matcher jmxMatcher = jmxRemotePortPattern.matcher(
+         * launchVmArguments ); String agentPortStr = null; if( aQutematcher.find() ) { agentPortStr =
+         * aQutematcher.group( 1 ); } if( !CoreUtil.empty( agentPortStr ) ) { aQuteAgentPort = Integer.parseInt(
+         * agentPortStr ); } String jmxPortStr = null; if( jmxMatcher.find() ) { jmxPortStr = jmxMatcher.group( 1 ); }
+         * if( !CoreUtil.empty( jmxPortStr ) ) { jmxPort = Integer.parseInt( jmxPortStr ); } } catch( Exception e ) {
+         * LiferayServerCore.logError( "can't get agent or jmx port from server launch configuration ", e ); }
+         */
 
         BundleSupervisor bundleSupervisor = new BundleSupervisor( jmxPort );
 
@@ -746,8 +719,7 @@ public class ServerUtil
         Properties categories = new Properties();
         Enumeration<?> names = props.propertyNames();
 
-        String[] controlPanelCategories =
-        {   "category.my", //$NON-NLS-1$
+        String[] controlPanelCategories = { "category.my", //$NON-NLS-1$
             "category.users", //$NON-NLS-1$
             "category.apps", //$NON-NLS-1$
             "category.configuration", //$NON-NLS-1$
@@ -794,7 +766,7 @@ public class ServerUtil
 
         if( sdk == null || !sdk.validate().isOK() )
         {
-            return null;
+            return new EmptyPortalBundle( "Unable to detect plugin sdk or plugin sdk setting are incorrent" );
         }
 
         final Map<String, Object> appServerProperties = sdk.getBuildProperties();
@@ -815,7 +787,8 @@ public class ServerUtil
             }
         }
 
-        return null;
+        return new EmptyPortalBundle(
+            "Unable to get Liferay Bundle by properties 'app.server.type=" + appServerType + "'" );
     }
 
     public static IRuntime getRuntime( org.eclipse.wst.common.project.facet.core.runtime.IRuntime runtime )
@@ -950,8 +923,7 @@ public class ServerUtil
 
         properties.put( ISDKConstants.PROPERTY_APP_SERVER_TYPE, type );
 
-        final String appServerDirKey =
-            getAppServerPropertyKey( ISDKConstants.PROPERTY_APP_SERVER_DIR, appServer );
+        final String appServerDirKey = getAppServerPropertyKey( ISDKConstants.PROPERTY_APP_SERVER_DIR, appServer );
         final String appServerDeployDirKey =
             getAppServerPropertyKey( ISDKConstants.PROPERTY_APP_SERVER_DEPLOY_DIR, appServer );
         final String appServerLibGlobalDirKey =
@@ -962,7 +934,8 @@ public class ServerUtil
         properties.put( appServerDirKey, dir );
         properties.put( appServerDeployDirKey, deployDir );
         properties.put( appServerLibGlobalDirKey, libGlobalDir );
-        //IDE-1268 need to always specify app.server.parent.dir, even though it is only useful in 6.1.2/6.2.0 or greater
+        // IDE-1268 need to always specify app.server.parent.dir, even though it is only useful in 6.1.2/6.2.0 or
+        // greater
         properties.put( ISDKConstants.PROPERTY_APP_SERVER_PARENT_DIR, parentDir );
         properties.put( appServerPortalDirKey, portalDir );
 
@@ -971,7 +944,8 @@ public class ServerUtil
 
     public static IServerManagerConnection getServerManagerConnection( IServer server, IProgressMonitor monitor )
     {
-        return LiferayServerCore.getRemoteConnection( (IRemoteServer) server.loadAdapter( IRemoteServer.class, monitor ) );
+        return LiferayServerCore.getRemoteConnection(
+            (IRemoteServer) server.loadAdapter( IRemoteServer.class, monitor ) );
     }
 
     public static IServer[] getServersForRuntime( IRuntime runtime )


### PR DESCRIPTION
hey Greg,
I found our error message is hard to read when we got from the error server.
I create the EmptyPortlalBundle to save the more detail when it failed to get from sdk.
Use it instead of "return null"