### PR TITLE
IDE-3623 adding liferay nature to maven module by bundling m2e features

### DIFF
--- a/build/com.liferay.ide-repository/hidden.features.product
+++ b/build/com.liferay.ide-repository/hidden.features.product
@@ -57,6 +57,7 @@
       <feature id="org.eclipse.tm.terminal.control.feature" />
       <feature id="org.eclipse.tm.terminal.view.feature" />
       <feature id="com.ianbrandt.tools.m2e.mdp.feature" />
+      <feature id="org.eclipse.m2e.sdk.feature" />
    </features>
 
    <configurations>

--- a/maven/features/com.liferay.ide.maven-feature/feature.xml
+++ b/maven/features/com.liferay.ide.maven-feature/feature.xml
@@ -35,7 +35,7 @@
    <requires>
       <import feature="org.eclipse.m2e.wtp.feature" version="1.2.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2e.wtp.jsf.feature" version="1.2.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.feature" version="1.6.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.9.0.20180110-1815" match="greaterOrEqual"/>
       <import feature="org.sonatype.m2e.mavenarchiver.feature" version="0.17" match="greaterOrEqual"/>
       <import feature="com.liferay.ide.eclipse.tools" version="3.0.0" match="greaterOrEqual"/>
       <import feature="org.sonatype.tycho.m2e.feature" version="0.8.0" match="greaterOrEqual"/>


### PR DESCRIPTION
@gamerson
I don't think this is the correct solution.

We need to select 'Update items already installed' to install the following two features, otherwise there will be an error about Only one of the following can be installed at once:

Maven Integration for Eclipse JDT UI 1.9.0.20171212-2050(org.eclipse.m2e.jdt.ui)  - Vanilla Eclipse-photon conatins it in plugins folder
Maven Integration for Eclipse JDT UI 1.9.0.20180110-1815 - in our m2e-site repo in build/parent/pom.xml

After choosing "update items already installed" to install Liferay IDE Maven Support then it will have liferay natures in maven module. 
Please someone help take a look when you're available, thanks. @jtydhr88 @simonjhy