### PR TITLE
IDE-3713 move base eclipse platform to Oxygen

### DIFF
--- a/build/com.liferay.ide-repository/category.xml
+++ b/build/com.liferay.ide-repository/category.xml
@@ -15,15 +15,6 @@
     <feature id="org.eclipse.buildship" version="0.0.0">
         <category name="liferay-ide" />
     </feature>
-    <feature id="org.eclipse.m2e.feature" version="0.0.0">
-        <category name="liferay-ide" />
-    </feature>
-    <feature id="org.eclipse.m2e.wtp.feature" version="0.0.0">
-        <category name="liferay-ide" />
-    </feature>
-    <feature id="org.eclipse.m2e.wtp.jsf.feature" version="0.0.0">
-        <category name="liferay-ide" />
-    </feature>
 
     <category-def name="liferay-ide" label="Liferay IDE">
         <description>

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -30,14 +30,14 @@
         <tycho-packaging-format>yyyyMMddHHmm'-m1'</tycho-packaging-format>
         <tycho-version>1.0.0</tycho-version>
         <tycho-extras-version>1.0.0</tycho-extras-version>
-        <eclipse-site>http://download.eclipse.org/releases/photon/</eclipse-site>
+        <eclipse-site>http://download.eclipse.org/releases/oxygen/</eclipse-site>
         <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/</orbit-site>
         <tm-site>http://download.eclipse.org/tm/terminal/updates/4.2/</tm-site>
         <liferay-ide-swtbot-testing-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide.testing-repository/target/repository/</liferay-ide-swtbot-testing-site>
         <osgi-bundles-site>https://repos-ide.wedeploy.io/liferay-ide-osgi-deps/</osgi-bundles-site>
         <ivy-site>https://dist.apache.org/repos/dist/release/ant/ivyde/updatesite/ivy-2.4.0.final_20141213170938/</ivy-site>
         <ivyde-site>https://dist.apache.org/repos/dist/release/ant/ivyde/updatesite/ivyde-2.2.0.final-201311091524-RELEASE/</ivyde-site>
-        <m2e-site>https://repos-ide.wedeploy.io/m2e/1.9.0.20180110-1815/</m2e-site>
+        <m2e-site>http://download.eclipse.org/technology/m2e/releases/</m2e-site>
         <m2e-wtp-site>http://download.eclipse.org/m2e-wtp/releases/oxygen/1.3/1.3.2.20170517-2015/</m2e-wtp-site>
         <m2e-archiver-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
         <eclipse-xml-search-site>https://dl.bintray.com/gamerson/eclipse-wtp-xml-search/</eclipse-xml-search-site>

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -43,7 +43,7 @@
         <eclipse-xml-search-site>https://dl.bintray.com/gamerson/eclipse-wtp-xml-search/</eclipse-xml-search-site>
         <tern-site>http://oss.opensagres.fr/tern.repository/1.2.1/</tern-site>
         <bndtools-site>https://bndtools.ci.cloudbees.com/job/bndtools.master/lastSuccessfulBuild/artifact/build/generated/p2/</bndtools-site>
-        <gradle-site>http://download.eclipse.org/buildship/updates/e46/releases/2.x/2.2.0.v20171211-1401/</gradle-site>
+        <gradle-site>http://download.eclipse.org/buildship/updates/e46/snapshots/2.x/2.2.1.v20180123-2310-s/</gradle-site>
         <tycho-m2e-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/0.9.0.201412222151/</tycho-m2e-site>
         <swtbot-site>http://download.eclipse.org/technology/swtbot/releases/2.6.0/</swtbot-site>
         <sapphire-site>http://download.eclipse.org/sapphire/9.1/repository/</sapphire-site>

--- a/maven/features/com.liferay.ide.maven-feature/feature.xml
+++ b/maven/features/com.liferay.ide.maven-feature/feature.xml
@@ -35,7 +35,7 @@
    <requires>
       <import feature="org.eclipse.m2e.wtp.feature" version="1.3.2" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2e.wtp.jsf.feature" version="1.3.2" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.feature" version="1.9.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.8.0" match="greaterOrEqual"/>
       <import feature="org.sonatype.m2e.mavenarchiver.feature" version="0.17" match="greaterOrEqual"/>
       <import feature="com.liferay.ide.eclipse.tools" version="3.0.0" match="greaterOrEqual"/>
       <import feature="org.sonatype.tycho.m2e.feature" version="0.8.0" match="greaterOrEqual"/>

--- a/tools/plugins/com.liferay.ide.project.ui/META-INF/MANIFEST.MF
+++ b/tools/plugins/com.liferay.ide.project.ui/META-INF/MANIFEST.MF
@@ -39,9 +39,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.views,
  org.eclipse.jem.util,
  org.eclipse.emf.ecore,
- org.eclipse.osgi.services,
- org.eclipse.equinox.ds,
- org.eclipse.equinox.util,
  com.liferay.ide.upgrade.core,
  org.apache.felix.gogo.runtime,
  org.eclipse.jem.workbench,
@@ -82,4 +79,3 @@ Export-Package: com.liferay.ide.project.ui,
  com.liferay.ide.project.ui.wizard,
  com.liferay.ide.project.ui.workspace
 Service-Component: OSGI-INF/com.liferay.ide.project.ui.migration.IDEReporter.xml
-Import-Package: com.google.common.cache


### PR DESCRIPTION
Updatesite installed ok on Windows and Linux now, thanks.
But on Mac, it prompts update is not permitted  for buildship. 