### PR TITLE
IDE-3693 improve adding runtime with jre warning

### DIFF
--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalRuntime.properties
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalRuntime.properties
@@ -1,4 +1,5 @@
 errorJRE=The JRE could not be found. Please edit the server to change the configured JRE
-errorJRE70=Portal version 7.0 requires Java 7 or later.  Change the JRE setting to JRE 1.7 or greater
+errorJRE80=Portal version 7.0 requires Java 8.  Change the JRE setting to JRE 1.8
 errorPortalNotExisted=Portal bundle does not exist
 errorPortalVersion70=Portal version must be greater 7.0
+warningjre=A full JDK (not just JRE) is recommended


### PR DESCRIPTION
Hey @gamerson as we tested portal 7/DXP could only run on Java8, there will be running errors if we choose java7 or java9.
Also portal 7/DXP needs a full jdk(we could use jre to start but there will be error if we deploy module with jsp files), so we add a warning if the user select a jre or not jdk.
Thanks @wangyq578 working on it and also thanks to @simonjhy helping review