### PR TITLE
Ide 3699

### DIFF
--- a/build/com.liferay.ide-repository/bundle/build.xml
+++ b/build/com.liferay.ide-repository/bundle/build.xml
@@ -258,7 +258,7 @@
         <delete dir="${eclipse.dir}" failonerror="true" includeemptydirs="true" />
     </target>
 
-    <target name="install-feature">
+    <target name="install-feature"  depends="update-feature">
         <exec executable="${builder.exe}" outputproperty="output" failonerror="true" dir="${target.dir}">
             <arg value="-nosplash" />
             <arg value="-application" />
@@ -283,6 +283,36 @@
             <arg value="${arch}" />
             <arg value="-roaming" />
         </exec>
+    </target>
+
+    <target name="update-feature">
+        <if>
+            <not>
+                <equals arg1="${update.features}" arg2="" />
+            </not>
+            <then>
+                <exec executable="${builder.exe}" outputproperty="output" failonerror="true" dir="${target.dir}">
+                    <arg value="-nosplash" />
+                    <arg value="-application" />
+                    <arg value="org.eclipse.equinox.p2.director" />
+                    <arg value="-uninstallIU" />
+                    <arg value="${update.features}" />
+                    <arg value="-destination" />
+                    <arg value="${eclipse.dir}" />
+                    <arg value="-profile" />
+                    <arg value="epp.package.jee" />
+                    <arg value="-bundlepool" />
+                    <arg value="${eclipse.dir}" />
+                    <arg value="-p2.os" />
+                    <arg value="${os}" />
+                    <arg value="-p2.ws" />
+                    <arg value="${ws}" />
+                    <arg value="-p2.arch" />
+                    <arg value="${arch}" />
+                    <arg value="-roaming" />
+                </exec>
+            </then>
+        </if>
     </target>
 
     <target name="install-all-features" depends="setup-builder">

--- a/build/com.liferay.ide-repository/bundle/bundle.properties
+++ b/build/com.liferay.ide-repository/bundle/bundle.properties
@@ -15,11 +15,11 @@ builder.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/
 
 ## 64-bit OSes
 
-eclipse.win64.zip.name=eclipse-jee-oxygen-1a-win32-x86_64.zip
-eclipse.win64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/oxygen/1a/eclipse-jee-oxygen-1a-win32-x86_64.zip
-eclipse.linux64.zip.name=eclipse-jee-oxygen-1a-linux-gtk-x86_64.tar.gz
-eclipse.linux64.tar.name=eclipse-jee-oxygen-1a-linux-gtk-x86_64.tar
-eclipse.linux64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/oxygen/1a/eclipse-jee-oxygen-1a-linux-gtk-x86_64.tar.gz
+eclipse.win64.zip.name=eclipse-jee-oxygen-2-win32-x86_64.zip
+eclipse.win64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/oxygen/2/eclipse-jee-oxygen-2-win32-x86_64.zip
+eclipse.linux64.zip.name=eclipse-jee-oxygen-2-linux-gtk-x86_64.tar.gz
+eclipse.linux64.tar.name=eclipse-jee-oxygen-2-linux-gtk-x86_64.tar
+eclipse.linux64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/oxygen/2/eclipse-jee-oxygen-2-linux-gtk-x86_64.tar.gz
 #eclipse.macosx64.zip.name=eclipse-jee-neon-3-macosx-cocoa-x86_64.tar.gz
 #eclipse.macosx64.tar.name=eclipse-jee-neon-3-macosx-cocoa-x86_64.tar
 #eclipse.macosx64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/neon/3/eclipse-jee-neon-3-macosx-cocoa-x86_64.tar.gz

--- a/build/com.liferay.ide-repository/bundle/bundle.properties
+++ b/build/com.liferay.ide-repository/bundle/bundle.properties
@@ -8,6 +8,7 @@ builder.dir=${rootdir}/builder/eclipse
 builder.exe=${builder.dir}/eclipse
 updatesite=file:repository
 all.features=com.liferay.ide.eclipse.tools.feature.group,com.liferay.ide.alloy.feature.group,com.liferay.ide.maven.feature.group,com.liferay.ide.enterprise.feature.group
+update.features=org.eclipse.buildship.feature.group
 
 builder.zip.name=eclipse-committers-mars-2-linux-gtk-x86_64.tar.gz
 builder.tar.name=eclipse-committers-mars-2-linux-gtk-x86_64.tar


### PR DESCRIPTION
Hi Greg,

This way we can install our Buildship 2.2 into our IDE bundles successfully. Creating modules work after testing.

And if using Buildship 2.1 which vanilla Eclipse oxygen contains, there will be Buildship and sapphire errors when clicking Finish button in "New Liferay Module Project" wizard.
![buildship-sapphire-error](https://user-images.githubusercontent.com/1308942/35604678-41c5cc04-067e-11e8-9c6f-59f4361b6228.png)

I'm not sure how to use "Update descriptor Advice" to update it, trying a "p2.inf" file doesn't work. If this doesn't look ok, can you please help about "Update Descriptor Advice" when you guys are  available?
@jtydhr88 

Thanks

