### PR TITLE
IDE-3729 do not show server view by default

### DIFF
--- a/tools/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/LiferayWorkspacePerspectiveFactory.java
+++ b/tools/plugins/com.liferay.ide.ui/src/com/liferay/ide/ui/LiferayWorkspacePerspectiveFactory.java
@@ -14,6 +14,7 @@
 
 package com.liferay.ide.ui;
 
+import com.liferay.ide.core.util.CoreUtil;
 import com.liferay.ide.ui.util.ProjectExplorerLayoutUtil;
 
 import org.eclipse.jdt.ui.JavaUI;
@@ -73,9 +74,11 @@ public class LiferayWorkspacePerspectiveFactory extends AbstractPerspectiveFacto
 
 		addViewIfExist(layout, topRightBottom, ID_GRADLE_EXECUTIONS_VIEW);
 
-		IFolderLayout bottomTopLeft = layout.createFolder("bottomTopLeft", IPageLayout.BOTTOM, 0.7F, "topLeft");
+		if (!CoreUtil.isLinux()) {
+			IFolderLayout bottomTopLeft = layout.createFolder("bottomTopLeft", IPageLayout.BOTTOM, 0.7F, "topLeft");
 
-		bottomTopLeft.addView(ID_SERVERS_VIEW);
+			bottomTopLeft.addView(ID_SERVERS_VIEW);
+		}
 
 		// Bottom
 


### PR DESCRIPTION
hey Greg & @simonjhy,
I know it is not a good solution but it is a satisfy solution, now we have a serious bug from eclipse https://bugs.eclipse.org/bugs/show_bug.cgi?id=473278 when we try to delete a server from server view(it existed from 3.1.2).
the key to solve this problem is to **re-render the part/view**, so there are several solutions but all of them are not good.
1. do not show server view on Linux and let user to open it if they need(I sent)
2. do not show LiferayWorkspacePerspective on Linux by default and let user to switch it when they need.
3. to let user change their the resolution of screen lower than 1080P(1980 * 1200), as Simon tested it works well with 1200*980.
 