### PR TITLE
update to valid eclipse builder site

### DIFF
--- a/build/com.liferay.ide-repository/bundle/bundle.properties
+++ b/build/com.liferay.ide-repository/bundle/bundle.properties
@@ -12,7 +12,7 @@ uninstall.features=org.eclipse.buildship.feature.group
 
 builder.zip.name=eclipse-committers-mars-2-linux-gtk-x86_64.tar.gz
 builder.tar.name=eclipse-committers-mars-2-linux-gtk-x86_64.tar
-builder.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/mars/2/eclipse-committers-mars-2-linux-gtk-x86_64.tar.gz
+builder.zip.url=http://archive.eclipse.org/technology/epp/downloads/release/mars/2/eclipse-committers-mars-2-linux-gtk-x86_64.tar.gz
 
 ## 64-bit OSes
 


### PR DESCRIPTION
The original link we used to download eclipse builder becomes invalid. Updated to an exiting url to download eclipse on our release.liferay.com Jenkins server.