### PR TITLE
IDE-4112 improve watch decoration and refresh this decorator immediately

### DIFF
--- a/tools/plugins/com.liferay.ide.gradle.ui/META-INF/MANIFEST.MF
+++ b/tools/plugins/com.liferay.ide.gradle.ui/META-INF/MANIFEST.MF
@@ -23,7 +23,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.team.ui,
  org.eclipse.jface.text,
  org.eclipse.jdt.ui,
- org.eclipse.ltk.core.refactoring
+ org.eclipse.ltk.core.refactoring,
+ org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/tools/plugins/com.liferay.ide.gradle.ui/src/com/liferay/ide/gradle/action/WatchTaskAction.java
+++ b/tools/plugins/com.liferay.ide.gradle.ui/src/com/liferay/ide/gradle/action/WatchTaskAction.java
@@ -22,6 +22,7 @@ import com.liferay.ide.project.ui.ProjectUI;
 import com.liferay.ide.server.core.ILiferayServer;
 import com.liferay.ide.server.core.gogo.GogoTelnetClient;
 import com.liferay.ide.ui.action.AbstractObjectAction;
+import com.liferay.ide.ui.util.UIUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,9 +51,13 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IDecoratorManager;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * @author Terry Jia
+ * @author Simon Jiang
  */
 public class WatchTaskAction extends AbstractObjectAction {
 
@@ -91,6 +96,8 @@ public class WatchTaskAction extends AbstractObjectAction {
 					try {
 						GradleUtil.runGradleTask(
 							project, new String[] {"watch"}, new String[] {"--continuous"}, monitor);
+
+						_refreshDecorator();
 					}
 					catch (Exception e) {
 						return ProjectUI.createErrorStatus("Error running Gradle watch task for project " + project, e);
@@ -132,6 +139,11 @@ public class WatchTaskAction extends AbstractObjectAction {
 						catch (IOException ioe) {
 							GradleUI.logError("Could not uninstall bundles installed by watch task", ioe);
 						}
+					}
+
+					@Override
+					public void running(IJobChangeEvent event) {
+						_refreshDecorator();
 					}
 
 				});
@@ -187,6 +199,21 @@ public class WatchTaskAction extends AbstractObjectAction {
 		}
 
 		return bndPaths;
+	}
+
+	private void _refreshDecorator() {
+		IWorkbench workbench = PlatformUI.getWorkbench();
+
+		IDecoratorManager decoratorManager = workbench.getDecoratorManager();
+
+		UIUtil.async(
+			new Runnable() {
+
+				public void run() {
+					decoratorManager.update("com.liferay.ide.gradle.ui.watchDecorator");
+				}
+
+			});
 	}
 
 }


### PR DESCRIPTION
hey Greg,
Simon and I resent this change as the decorator that Simon is working on, is not decorate on the eclipse Server view, it works for Project tree.
Actually the watch task self has no relate to the eclipse server view. it just run gradle watch task, that means it could work all running server locally but not only in eclipse.