### PR TITLE
IDE-4430 A better solution for the issue of IDE-4329

### DIFF
--- a/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/eclipse/provider/ProjectMigrationService.java
+++ b/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/eclipse/provider/ProjectMigrationService.java
@@ -392,6 +392,14 @@ public class ProjectMigrationService implements Migration {
 					return FileVisitResult.SKIP_SUBTREE;
 				}
 
+				if (dir.endsWith("out") && dir.startsWith(startDir.getPath())) {
+					return FileVisitResult.SKIP_SUBTREE;
+				}
+
+				if (dir.endsWith("build") && dir.startsWith(startDir.getPath())) {
+					return FileVisitResult.SKIP_SUBTREE;
+				}
+
 				if (dir.endsWith("target") && dir.startsWith(startDir.getPath())) {
 					return FileVisitResult.SKIP_SUBTREE;
 				}


### PR DESCRIPTION
Hi @gamerson 

The issue of IDE-4329 is that the breaking changes should not be found in build folder.
On IDE-4329, my solution is that, find all the problems then remove the problems in build folder.
Actually, we can ignore these problems in build folder when counting total like what we did before, this pr is the new solution.

Br,
Seiphon