### PR TITLE
revert bndtools from 4.2 to 4.0

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -41,7 +41,7 @@
         <m2e-wtp-site>https://download.eclipse.org/m2e-wtp/releases/1.4/1.4.1.20181128-2152</m2e-wtp-site>
         <m2e-archiver-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
         <eclipse-xml-search-site>https://dl.bintray.com/gamerson/eclipse-wtp-xml-search/</eclipse-xml-search-site>
-        <bndtools-site>https://dl.bintray.com/bndtools/bndtools/4.2.0/</bndtools-site>
+        <bndtools-site>https://dl.bintray.com/bndtools/bndtools/4.0.0/</bndtools-site>
         <gradle-site>https://download.eclipse.org/buildship/updates/e48/snapshots/3.x/3.0.2.v20181217-2319-s</gradle-site>
         <tycho-m2e-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/0.9.0.201412222151/</tycho-m2e-site>
         <swtbot-site>http://download.eclipse.org/technology/swtbot/releases/2.6.0/</swtbot-site>

--- a/maven/features/com.liferay.ide.maven-feature/feature.xml
+++ b/maven/features/com.liferay.ide.maven-feature/feature.xml
@@ -41,7 +41,7 @@
 		<import feature="com.liferay.ide.eclipse.tools" match="greaterOrEqual" version="3.0.0" />
 		<import feature="org.sonatype.tycho.m2e.feature" match="greaterOrEqual" version="0.8.0" />
 		<import feature="com.ianbrandt.tools.m2e.mdp.feature" match="greaterOrEqual" version="0.0.4" />
-		<import feature="bndtools.m2e.feature" match="greaterOrEqual" version="4.2.0" />
+		<import feature="bndtools.m2e.feature" match="greaterOrEqual" version="4.0.0" />
 	</requires>
 
 	<plugin

--- a/tools/features/com.liferay.ide.eclipse.tools/feature.xml
+++ b/tools/features/com.liferay.ide.eclipse.tools/feature.xml
@@ -33,7 +33,7 @@
 	</license>
 
 	<requires>
-		<import feature="bndtools.main.feature" match="greaterOrEqual" version="4.2.0" />
+		<import feature="bndtools.main.feature" match="greaterOrEqual" version="4.0.0" />
 		<import feature="org.apache.ivy.feature" match="greaterOrEqual" version="2.3.0" />
 		<import feature="org.apache.ivyde.feature" match="greaterOrEqual" version="2.2.0" />
 		<import feature="org.eclipse.buildship" match="greaterOrEqual" version="2.1.1" />


### PR DESCRIPTION
Hi Greg,

I'm reverting bndtools to make maven core tests run successful:

For example: http://cloud-10-50-0-162:8081/job/liferay-ide-pr-tester/2120/testReport/b 

> "bndtools.m2e.bndconfigurator" required by plugin execution "biz.aQute.bnd:bnd-maven-plugin:4.2.0:bnd-process (execution: default, phase: process-classes)" is not available. To enable full functionality, install the project configurator and run Maven->Update Project Configuration.

On bndtools 4.2, bndtools.m2e.bndconfigurator is not installed, as talked to @jtydhr88, could we revert this for now? Please help take a look when you're available, thanks.