### PR TITLE
IDE-4466 add legacy to new sdk releated wizards

### DIFF
--- a/tools/plugins/com.liferay.ide.hook.ui/src/com/liferay/ide/hook/ui/wizard/NewHookWizard.properties
+++ b/tools/plugins/com.liferay.ide.hook.ui/src/com/liferay/ide/hook/ui/wizard/NewHookWizard.properties
@@ -1,1 +1,1 @@
-newLiferayHook=New Liferay Hook
+newLiferayHook=New Liferay Hook (Legacy)

--- a/tools/plugins/com.liferay.ide.layouttpl.ui/src/com/liferay/ide/layouttpl/ui/wizard/NewLayoutTplWizard.properties
+++ b/tools/plugins/com.liferay.ide.layouttpl.ui/src/com/liferay/ide/layouttpl/ui/wizard/NewLayoutTplWizard.properties
@@ -1,1 +1,1 @@
-newLayoutTemplate=New Layout Template
+newLayoutTemplate=New Layout Template (Legacy)

--- a/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/ui/jsf/NewJSFPortletWizard.properties
+++ b/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/ui/jsf/NewJSFPortletWizard.properties
@@ -1,5 +1,5 @@
 createJSFPortlet=Create a JSF portlet.
 createLiferayJSFPortlet=Create Liferay JSF Portlet
-newLiferayJSFPortlet=New Liferay JSF Portlet
+newLiferayJSFPortlet=New Liferay JSF Portlet (Legacy)
 specifyJSFPortletDeployment=Specify JSF portlet deployment descriptor details.
 specifyLiferayPortletDeployment=Specify Liferay portlet deployment descriptor details.

--- a/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/ui/wizard/NewPortletWizard.properties
+++ b/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/ui/wizard/NewPortletWizard.properties
@@ -1,6 +1,6 @@
 createLiferayPortlet=Create Liferay Portlet
 createPortletClass=Create a portlet class.
-newLiferayPortlet=New Liferay Portlet
+newLiferayPortlet=New Liferay Portlet (Legacy)
 specifyLiferayPortletDeployment=Specify Liferay portlet deployment descriptor details.
 specifyModifiersInterfacesMethodStubs=Specify modifiers, interfaces, and method stubs to generate in Portlet class.
 specifyPortletDeployment=Specify portlet deployment descriptor details.

--- a/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/vaadin/ui/wizard/NewVaadinPortletWizard.properties
+++ b/tools/plugins/com.liferay.ide.portlet.ui/src/com/liferay/ide/portlet/vaadin/ui/wizard/NewVaadinPortletWizard.properties
@@ -1,5 +1,5 @@
 createLiferayVaadinPortlet=Create Liferay Vaadin Portlet
 createVaadinPortletApplicationClass=Create a Vaadin portlet application class.
-newLiferayVaadinPortlet=New Liferay Vaadin Portlet
+newLiferayVaadinPortlet=New Liferay Vaadin Portlet (Legacy)
 specifyLiferayPortletDeployment=Specify Liferay portlet deployment descriptor details.
 specifyVaadinPortletDeployment=Specify Vaadin portlet deployment descriptor details.

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/wizard/ImportSDKProjectsWizard.sdef
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/wizard/ImportSDKProjectsWizard.sdef
@@ -25,7 +25,7 @@
     <wizard>
         <id>ImportSDKProjectsWizard</id>
         <element-type>com.liferay.ide.project.core.model.SDKProjectsImportOp</element-type>
-        <label>Import Liferay Plugins SDK Projects</label>
+        <label>Import Liferay Plugins SDK Projects (Legacy)</label>
         <page>
             <id>ImportLiferaySDKProjectsPage</id>
             <label>Import Liferay Plugins SDK Projects</label>

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/wizard/NewLiferayPluginProjectWizard.sdef
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/wizard/NewLiferayPluginProjectWizard.sdef
@@ -25,7 +25,7 @@
     <wizard>
         <id>NewLiferayPluginProjectWizard</id>
         <element-type>com.liferay.ide.project.core.model.NewLiferayPluginProjectOp</element-type>
-        <label>New Liferay Plugin Project</label>
+        <label>New Liferay Plugin Project (Legacy)</label>
         <page>
             <id>LiferayPluginProjectWizardPage</id>
             <label>Liferay Plugin Project</label>

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/wizard/ParentSDKProjectImportWizard.sdef
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/wizard/ParentSDKProjectImportWizard.sdef
@@ -25,7 +25,7 @@
     <wizard>
         <id>ParentSDKProjectImportWizard</id>
         <element-type>com.liferay.ide.project.core.model.ParentSDKProjectImportOp</element-type>
-        <label>Import Liferay Plugins SDK Parent Project</label>
+        <label>Import Liferay Plugins SDK Parent Project (Legacy)</label>
         <page>
             <id>ImportLiferayParentSDKPage</id>
             <label>Liferay Plugins SDK Parent Project</label>

--- a/tools/plugins/com.liferay.ide.service.ui/OSGI-INF/l10n/bundle.properties
+++ b/tools/plugins/com.liferay.ide.service.ui/OSGI-INF/l10n/bundle.properties
@@ -9,4 +9,4 @@ category.name = Liferay
 context.type.name = New Service Builder
 service.editor.name = Service Builder Configuration Editor
 service.wizard.description = Create a new Liferay Service
-service.wizard.name = Liferay Service Builder (Legacy)
+service.wizard.name = Liferay Service Builder


### PR DESCRIPTION
Remove legacy from new liferay service builder wizard.
But the wizard can only recognize plugin project right now, have created a ticket: IDE-4585 for supporting creating service builder on module projects. cc @jtydhr88 