### PR TITLE
add external properties support

### DIFF
--- a/tools/plugins/com.liferay.ide.upgrade.plan.core/src/com/liferay/ide/upgrade/plan/core/UpgradePlan.java
+++ b/tools/plugins/com.liferay.ide.upgrade.plan.core/src/com/liferay/ide/upgrade/plan/core/UpgradePlan.java
@@ -30,6 +30,8 @@ public interface UpgradePlan {
 
 	public String getCurrentVersion();
 
+	public String getExternalProperty(String key);
+
 	public String getName();
 
 	public Path getTargetProjectLocation();
@@ -45,6 +47,8 @@ public interface UpgradePlan {
 	public List<String> getUpgradeVersions();
 
 	public void setCurrentProjectLocation(Path path);
+
+	public void setExternalProperty(String key, String value);
 
 	public void setTargetProjectLocation(Path path);
 

--- a/tools/plugins/com.liferay.ide.upgrade.plan.core/src/com/liferay/ide/upgrade/plan/core/internal/StandardUpgradePlan.java
+++ b/tools/plugins/com.liferay.ide.upgrade.plan.core/src/com/liferay/ide/upgrade/plan/core/internal/StandardUpgradePlan.java
@@ -23,7 +23,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Stream;
@@ -89,6 +91,11 @@ public class StandardUpgradePlan implements UpgradePlan {
 	@Override
 	public String getCurrentVersion() {
 		return _currentVersion;
+	}
+
+	@Override
+	public String getExternalProperty(String key) {
+		return externalProperties.get(key);
 	}
 
 	@Override
@@ -207,6 +214,11 @@ public class StandardUpgradePlan implements UpgradePlan {
 	}
 
 	@Override
+	public void setExternalProperty(String key, String value) {
+		externalProperties.put(key, value);
+	}
+
+	@Override
 	public void setTargetProjectLocation(Path path) {
 		_targetProjectLocation = path;
 	}
@@ -228,5 +240,6 @@ public class StandardUpgradePlan implements UpgradePlan {
 	private String _upgradePlanOutline;
 	private Set<UpgradeProblem> _upgradeProblems;
 	private final List<UpgradeStep> _upgradeSteps;
+	private final Map<String, String> externalProperties = new HashMap<>();
 
 }


### PR DESCRIPTION
hey @gamerson I add this properties to prepare support legacy plugins, as they will need some configs we do not have yet, like 62 server location and so on, but I do not want to add too much set/get methods in UpgradePlan class, so I add a Map to do so.