### PR TITLE
Ide 4700 update orbit and remove unused requirements on asm 6.0.0

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -43,7 +43,7 @@
         <m2e-archiver-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
         <maven-deps-plugin-site>https://github.com/ianbrandt/m2e-maven-dependency-plugin/raw/gh-pages/0.0.4/</maven-deps-plugin-site>
-        <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/</orbit-site>
+        <orbit-site>https://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/</orbit-site>
         <osgi-bundles-site>https://dl.bintray.com/gamerson/eclipse/liferay-ide-deps/201904221700/</osgi-bundles-site>
         <sapphire-site>http://download.eclipse.org/sapphire/9.1.1/repository/</sapphire-site>
         <sign-apps>false</sign-apps>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -33,7 +33,7 @@
 
 	<properties>
 		<eclipse-site>https://download.eclipse.org/releases/2018-12/201812191000/</eclipse-site>
-		<tycho-version>1.3.0</tycho-version>
+		<tycho-version>1.4.0</tycho-version>
 		<liferay-ide-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide-repository/target/repository/</liferay-ide-site>
 	</properties>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -33,7 +33,7 @@
 
 	<properties>
 		<eclipse-site>https://download.eclipse.org/releases/2018-12/201812191000/</eclipse-site>
-		<tycho-version>1.3.0</tycho-version>
+		<tycho-version>1.4.0</tycho-version>
 		<liferay-ide-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide-repository/target/repository/</liferay-ide-site>
 	</properties>
 

--- a/tools/features/com.liferay.ide.hidden/feature.xml
+++ b/tools/features/com.liferay.ide.hidden/feature.xml
@@ -142,12 +142,4 @@
 		version="5.2.0.v20170126-0011"
 	/>
 
-	<plugin
-		download-size="0"
-		id="org.objectweb.asm"
-		install-size="0"
-		unpack="false"
-		version="6.0.0.v20180414-0329"
-	/>
-
 </feature>

--- a/tools/features/com.liferay.ide.upgrade.planner/feature.xml
+++ b/tools/features/com.liferay.ide.upgrade.planner/feature.xml
@@ -292,22 +292,6 @@
 
 	<plugin
 		download-size="0"
-		id="org.objectweb.asm"
-		install-size="0"
-		unpack="false"
-		version="5.2.0.v20170126-0011"
-	/>
-
-	<plugin
-		download-size="0"
-		id="org.objectweb.asm"
-		install-size="0"
-		unpack="false"
-		version="6.0.0.v20180414-0329"
-	/>
-
-	<plugin
-		download-size="0"
 		id="com.liferay.ide.upgrade.planner.ui"
 		install-size="0"
 		unpack="false"


### PR DESCRIPTION
Already bundled asm 5.2 in our hidden/feature.xml, which is the one sapphire requires[4.0,6.0).
With this commit, our updatesite can install successfully on Eclipse Photon, 201812 and 201912.