### PR TITLE
IDE-4702 update default memory args and custom launch settings to 2560M

### DIFF
--- a/tools/plugins/com.liferay.ide.server.core/preferences.ini
+++ b/tools/plugins/com.liferay.ide.server.core/preferences.ini
@@ -5,4 +5,4 @@ adjust.deployment.timestamp=true
 default.username=test@liferay.com
 default.password=
 
-default.memory.args=-Xmx1024m
+default.memory.args=-Xmx2560m

--- a/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerConstants.java
+++ b/tools/plugins/com.liferay.ide.server.core/src/com/liferay/ide/server/core/portal/PortalServerConstants.java
@@ -33,7 +33,7 @@ public interface PortalServerConstants {
 
 	public IEclipsePreferences defaultPrefs = DefaultScope.INSTANCE.getNode(LiferayServerCore.PLUGIN_ID);
 
-	public String DEFAULT_MEMORY_ARGS = defaultPrefs.get("default.memory.args", "-Xmx1024m");
+	public String DEFAULT_MEMORY_ARGS = defaultPrefs.get("default.memory.args", "-Xmx2560m");
 
 	public String DEFAULT_USERNAME = "test@liferay.com";
 

--- a/tools/plugins/com.liferay.ide.server.tomcat.core/preferences.ini
+++ b/tools/plugins/com.liferay.ide.server.tomcat.core/preferences.ini
@@ -9,6 +9,6 @@ tomcat-i18n-es.jar,\
 tomcat-i18n-fr.jar,\
 tomcat-i18n-ja.jar
 
-default.memory.args=-Xmx1024m
+default.memory.args=-Xmx2560m
 default.user.timezone=GMT
 default.auto.deploy.interval=1000

--- a/tools/plugins/com.liferay.ide.server.tomcat.core/src/com/liferay/ide/server/tomcat/core/ILiferayTomcatConstants.java
+++ b/tools/plugins/com.liferay.ide.server.tomcat.core/src/com/liferay/ide/server/tomcat/core/ILiferayTomcatConstants.java
@@ -34,7 +34,7 @@ public interface ILiferayTomcatConstants {
 
 	public static final String DEFAULT_DEPLOYDIR = "webapps";
 
-	public static final String DEFAULT_MEMORY_ARGS = defaultPrefs.get("default.memory.args", "-Xmx1024m");
+	public static final String DEFAULT_MEMORY_ARGS = defaultPrefs.get("default.memory.args", "-Xmx2560m");
 
 	public static final boolean DEFAULT_USE_DEFAULT_PORTAL_SERVER_SETTING = false;
 


### PR DESCRIPTION
Increase memory args to -Xmx 2560M since portal is using 2560 by default.