### PR TITLE
update maven central to HTTPS since insecure HTTP is not supportted

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -40,7 +40,7 @@
         <liferay-ide-tag>ga1</liferay-ide-tag>
         <m2e-site>http://download.eclipse.org/technology/m2e/releases/1.13/1.13.0.20190716-1624/</m2e-site>
         <m2e-wtp-site>http://download.eclipse.org/m2e-wtp/releases/1.4/1.4.2.20190530-0057/</m2e-wtp-site>
-        <m2e-archiver-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
+        <m2e-archiver-site>https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
         <maven-deps-plugin-site>https://github.com/ianbrandt/m2e-maven-dependency-plugin/raw/gh-pages/0.0.4/</maven-deps-plugin-site>
         <orbit-site>https://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/</orbit-site>
@@ -50,7 +50,7 @@
         <swtbot-site>http://download.eclipse.org/technology/swtbot/releases/2.8.0/</swtbot-site>
         <tm-site>https://download.eclipse.org/tm/updates/4.5.0/repository/</tm-site>
         <tycho-extras-version>1.0.0</tycho-extras-version>
-        <tycho-m2e-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/0.9.0.201811261502/</tycho-m2e-site>
+        <tycho-m2e-site>https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/0.9.0.201811261502/</tycho-m2e-site>
         <tycho-packaging-format>yyyyMMddHHmm'-ga1'</tycho-packaging-format>
         <tycho-version>1.4.0</tycho-version>
     </properties>


### PR DESCRIPTION
According to the following artiacle, from Jan 15, 2020, the Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.

https://support.sonatype.com/hc/en-us/articles/360041287334