### PR TITLE
Query about github action runner space

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,13 +41,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-#      - name: Cache
-#        uses: actions/cache@v1.1.0
-#        with: 
-#          path: liferay-ide-m2-repository/.cache
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven- 
+      - name: Cache
+        uses: actions/cache@v1.1.0
+        with:
+          path: liferay-ide-m2-repository/.cache/download-maven-plugin
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,6 +41,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+ #     - name: Free space
+ #       run: |
+ #         sudo swapoff -a
+ #         sudo swapon -a
+ #         sudo chattr -i /swapfile
+ #         sudo rm -f /swapfile
+ #         docker rmi $(docker image ls -aq)
       - name: Cache
         uses: actions/cache@v1.1.0
         with:


### PR DESCRIPTION
Hi @gamerson , I've using 'df -h' to check the space on server: 84G, used 69G, available 15G

- /opt 12G
- /usr 42G
  - /usr/lib 5.3G
  - /usr/share 20G
    - /usr/share/dotnet 17G
  - /usr/local 16G
    - /usr/local/lib 9.6G
    - /usr/local/share 4.2G
- /home 1.8G
  - /home/runner/work 1.5G
  - /home/runner/work/liferay-ide 1.1G
- /swapfile 8.1G

Cache folder is about 148M. In this case, can we remove /swapfile? Also, here is the infos about docker on a fresh runner, can we remove all the docker images?

![docker-containers](https://user-images.githubusercontent.com/1308942/76980094-b9f1ab80-6973-11ea-800f-39801e3674f7.png)

