### PR TITLE
remove swapfile and docker images to free space

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,6 +41,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Free space
+        run: |
+          sudo swapoff -a
+          sudo swapon -a
+          sudo swapoff /swapfile
+          sudo rm -f /swapfile
+          docker rmi $(docker image ls -aq)
+          df -h
       - name: Cache
         uses: actions/cache@v1.1.0
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,13 +41,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-#      - name: Cache
-#        uses: actions/cache@v1.1.0
-#        with: 
-#          path: liferay-ide-m2-repository/.cache
-#          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-maven- 
+      - name: Cache
+        uses: actions/cache@v1.1.0
+        with:
+          path: liferay-ide-m2-repository/.cache/download-maven-plugin
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Run tests
         shell: bash
         run: |


### PR DESCRIPTION
Once remove /swapfile and all docker images, it will save almost 11G, there will be 26G available, hope this will help.  And I've run a few times. 'Run tests' and 'No enough space' are no shown yet.