### PR TITLE
IDE-4770 use api.liferay.com instead of private url for dxp bundle

### DIFF
--- a/tests-resources/projects/test-liferay-workspace-ee/gradle.properties
+++ b/tests-resources/projects/test-liferay-workspace-ee/gradle.properties
@@ -124,4 +124,4 @@
     microsoft.translator.client.id=
     microsoft.translator.client.secret=
 
-    liferay.workspace.bundle.url=https://files.liferay.com/private/ee/portal/7.0.10.6/liferay-dxp-digital-enterprise-tomcat-7.0-sp6-20171010144253003.zip
+    liferay.workspace.bundle.url=https://api.liferay.com/downloads/portal/7.0.10.6/liferay-dxp-digital-enterprise-tomcat-7.0-sp6-20171010144253003.zip


### PR DESCRIPTION
junit - use ce bundles
integration - **except for the update in this commit,** other links are using https://api.liferay.com
funcation - not use urls, we upload dxp bundles manually to test servers
installers - using https://api.liferay.com already