### PR TITLE
IDE-4769 remove support for token and bundle support file

### DIFF
--- a/build/installers/liferay-workspace-with-devstudio-ce/liferay-workspace-with-devstudio-ce.xml
+++ b/build/installers/liferay-workspace-with-devstudio-ce/liferay-workspace-with-devstudio-ce.xml
@@ -26,9 +26,6 @@
                             <origin>../shared/download/gw.jar</origin>
                         </distributionFile>
                         <distributionFile>
-                            <origin>../shared/download/com.liferay.portal.tools.bundle.support.jar</origin>
-                        </distributionFile>
-                        <distributionFile>
                             <origin>../shared/download/biz.aQute.bnd.jar</origin>
                         </distributionFile>
                     </distributionFileList>
@@ -414,9 +411,6 @@
         </deleteFile>
         <deleteFile>
             <path>${installdir}${platform_path_separator}biz.aQute.jpm.run.jar</path>
-        </deleteFile>
-        <deleteFile>
-            <path>${installdir}${platform_path_separator}com.liferay.portal.tools.bundle.support.jar</path>
         </deleteFile>
         <deleteFile>
             <path>${installdir}${platform_path_separator}biz.aQute.bnd.jar</path>

--- a/build/installers/liferay-workspace-with-devstudio-ce/pom.xml
+++ b/build/installers/liferay-workspace-with-devstudio-ce/pom.xml
@@ -92,20 +92,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>download-bundle-support</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>${bundle-support-download-base}/${bundle-support-version}/${bundle-support-name}</url>
-                            <outputDirectory>../shared/download/</outputDirectory>
-                            <outputFileName>com.liferay.portal.tools.bundle.support.jar</outputFileName>
-                            <md5>${bundle-support-md5}</md5>
-                            <checkSignature>true</checkSignature>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>download-jpmcli</id>
                         <phase>package</phase>
                         <goals>

--- a/build/installers/liferay-workspace-with-devstudio-dxp/liferay-workspace-with-devstudio-dxp.xml
+++ b/build/installers/liferay-workspace-with-devstudio-dxp/liferay-workspace-with-devstudio-dxp.xml
@@ -26,9 +26,6 @@
                             <origin>../shared/download/gw.jar</origin>
                         </distributionFile>
                         <distributionFile>
-                            <origin>../shared/download/com.liferay.portal.tools.bundle.support.jar</origin>
-                        </distributionFile>
-                        <distributionFile>
                             <origin>../shared/download/biz.aQute.bnd.jar</origin>
                         </distributionFile>
                     </distributionFileList>
@@ -189,27 +186,10 @@
                     <path>${installdir}${platform_path_separator}pwd</path>
                     <text>${password.password}</text>
                 </writeFile>
-                <runProgram>
-                    <customErrorMessage>Could not create DXP download token. Make sure you type correct email address and password and are connected to the internet.</customErrorMessage>
-                    <program>${java_executable}</program>
-                    <programArguments>-jar${proxyHostArg}${proxyPortArg}${proxyUsernameArg}${proxyPasswordArg} "${installdir}${platform_path_separator}com.liferay.portal.tools.bundle.support.jar" createToken --force --email "${email}" --password-file "${installdir}${platform_path_separator}pwd" --token-file "${userHome}${platform_path_separator}.liferay${platform_path_separator}token"</programArguments>
-                    <onErrorActionList>
-                        <deleteFile>
-                            <path>${installdir}</path>
-                        </deleteFile>
-                    </onErrorActionList>
-                </runProgram>
                 <deleteFile>
                     <path>${installdir}${platform_path_separator}pwd</path>
                 </deleteFile>
             </actionList>
-            <conditionRuleList>
-                <isTrue value="${clitools}"/>
-                <fileTest>
-                    <condition>not_exists</condition>
-                    <path>${userHome}${platform_path_separator}.liferay${platform_path_separator}token</path>
-                </fileTest>
-            </conditionRuleList>
         </if>
         <if>
             <explanation>is linux</explanation>
@@ -405,11 +385,6 @@
                 </runProgram>
                 <propertiesFileSet>
                     <file>${lrws}${platform_path_separator}gradle.properties</file>
-                    <key>liferay.workspace.bundle.token.download</key>
-                    <value>true</value>
-                </propertiesFileSet>
-                <propertiesFileSet>
-                    <file>${lrws}${platform_path_separator}gradle.properties</file>
                     <key>liferay.workspace.bundle.url</key>
                     <value>https://api.liferay.com/downloads/portal/7.2.10/liferay-dxp-tomcat-7.2.10-ga1-20190531140450482.tar.gz</value>
                 </propertiesFileSet>
@@ -578,9 +553,6 @@
             <path>${installdir}${platform_path_separator}biz.aQute.jpm.run.jar</path>
         </deleteFile>
         <deleteFile>
-            <path>${installdir}${platform_path_separator}com.liferay.portal.tools.bundle.support.jar</path>
-        </deleteFile>
-        <deleteFile>
             <path>${installdir}${platform_path_separator}biz.aQute.bnd.jar</path>
         </deleteFile>
         <deleteFile>
@@ -675,44 +647,6 @@
                 </directoryParameter>
             </parameterList>
         </booleanParameterGroup>
-        <parameterGroup>
-            <name>dxpinfo</name>
-            <title>Download Liferay DXP Bundle</title>
-            <explanation>Email address and password are used for generating a download token. Your password will not be saved locally.</explanation>
-            <value></value>
-            <default></default>
-            <parameterList>
-                <stringParameter>
-                    <name>email</name>
-                    <title>liferay.com email address</title>
-                    <description>liferay.com Email Address:</description>
-                    <explanation></explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>1</allowEmptyValue>
-                    <width>30</width>
-                </stringParameter>
-                <passwordParameter>
-                    <name>password</name>
-                    <title>Password</title>
-                    <description>liferay.com Email Password:</description>
-                    <explanation></explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>1</allowEmptyValue>
-                    <askForConfirmation>0</askForConfirmation>
-                    <descriptionRetype></descriptionRetype>
-                    <width>20</width>
-                </passwordParameter>
-            </parameterList>
-            <ruleList>
-                <fileTest>
-                    <condition>not_exists</condition>
-                    <path>${userHome}${platform_path_separator}.liferay${platform_path_separator}token</path>
-                </fileTest>
-                <isTrue value="${clitools}"/>
-            </ruleList>
-        </parameterGroup>
         <fileParameter>
             <name>activationKey</name>
             <title>DXP Activation Key (Optional)</title>

--- a/build/installers/liferay-workspace-with-devstudio-dxp/pom.xml
+++ b/build/installers/liferay-workspace-with-devstudio-dxp/pom.xml
@@ -92,20 +92,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>download-bundle-support</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>${bundle-support-download-base}/${bundle-support-version}/${bundle-support-name}</url>
-                            <outputDirectory>../shared/download/</outputDirectory>
-                            <outputFileName>com.liferay.portal.tools.bundle.support.jar</outputFileName>
-                            <md5>${bundle-support-md5}</md5>
-                            <checkSignature>true</checkSignature>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>download-jpmcli</id>
                         <phase>package</phase>
                         <goals>

--- a/build/installers/liferay-workspace/liferay-workspace.xml
+++ b/build/installers/liferay-workspace/liferay-workspace.xml
@@ -23,9 +23,6 @@
                             <origin>../shared/download/blade.jar</origin>
                         </distributionFile>
                         <distributionFile>
-                            <origin>../shared/download/com.liferay.portal.tools.bundle.support.jar</origin>
-                        </distributionFile>
-                        <distributionFile>
                             <origin>../shared/download/biz.aQute.bnd.jar</origin>
                         </distributionFile>
                         <distributionFile>
@@ -178,16 +175,6 @@
                     <path>${installdir}${platform_path_separator}pwd</path>
                     <text>${password.password}</text>
                 </writeFile>
-                <runProgram>
-                    <customErrorMessage>Could not create DXP download token. Make sure you type correct email address and password and are connected to the internet.</customErrorMessage>
-                    <program>${java_executable}</program>
-                    <programArguments>-jar${proxyHostArg}${proxyPortArg}${proxyUsernameArg}${proxyPasswordArg} "${installdir}${platform_path_separator}com.liferay.portal.tools.bundle.support.jar" createToken --force --email "${email}" --password-file "${installdir}${platform_path_separator}pwd" --token-file "${userHome}${platform_path_separator}.liferay${platform_path_separator}token"</programArguments>
-                    <onErrorActionList>
-                        <deleteFile>
-                            <path>${installdir}</path>
-                        </deleteFile>
-                    </onErrorActionList>
-                </runProgram>
                 <deleteFile>
                     <path>${installdir}${platform_path_separator}pwd</path>
                 </deleteFile>
@@ -198,10 +185,6 @@
                     <value1>${isdxp}</value1>
                     <value2>dxp</value2>
                 </compareValues>
-                <fileTest>
-                    <condition>not_exists</condition>
-                    <path>${userHome}${platform_path_separator}.liferay${platform_path_separator}token</path>
-                </fileTest>
                 <compareValues>
                     <logic>equals</logic>
                     <value1>${initlrws}</value1>
@@ -351,18 +334,6 @@
                     <file>${lrwsDir}${platform_path_separator}gradle.properties</file>
                     <key>liferay.workspace.bundle.url</key>
                     <value>https://api.liferay.com/downloads/portal/7.2.10/liferay-dxp-tomcat-7.2.10-ga1-20190531140450482.tar.gz</value>
-                    <ruleList>
-                        <compareValues>
-                            <logic>equals</logic>
-                            <value1>${isdxp}</value1>
-                            <value2>dxp</value2>
-                        </compareValues>
-                    </ruleList>
-                </propertiesFileSet>
-                <propertiesFileSet>
-                    <file>${lrwsDir}${platform_path_separator}gradle.properties</file>
-                    <key>liferay.workspace.bundle.token.download</key>
-                    <value>true</value>
                     <ruleList>
                         <compareValues>
                             <logic>equals</logic>
@@ -703,48 +674,6 @@
                 </compareValues>
             </ruleList>
         </choiceParameterGroup>
-        <parameterGroup>
-            <name>dxpinfo</name>
-            <title>Liferay DXP Customer Credentials</title>
-            <explanation>Email address and password are used for generating a download token. Your password will not be saved locally.</explanation>
-            <value></value>
-            <default></default>
-            <parameterList>
-                <stringParameter>
-                    <name>email</name>
-                    <title>Email</title>
-                    <description>liferay.com Email Address:</description>
-                    <explanation></explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>1</allowEmptyValue>
-                    <width>30</width>
-                </stringParameter>
-                <passwordParameter>
-                    <name>password</name>
-                    <title>Password</title>
-                    <description>liferay.com Password:</description>
-                    <explanation></explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>1</allowEmptyValue>
-                    <askForConfirmation>0</askForConfirmation>
-                    <descriptionRetype></descriptionRetype>
-                    <width>20</width>
-                </passwordParameter>
-            </parameterList>
-            <ruleList>
-                <compareValues>
-                    <logic>equals</logic>
-                    <value1>${isdxp}</value1>
-                    <value2>dxp</value2>
-                </compareValues>
-                <fileTest>
-                    <condition>not_exists</condition>
-                    <path>${userHome}${platform_path_separator}.liferay${platform_path_separator}token</path>
-                </fileTest>
-            </ruleList>
-        </parameterGroup>
         <choiceParameterGroup>
             <name>proxy</name>
             <description>Proxy Configuration</description>

--- a/build/installers/liferay-workspace/pom.xml
+++ b/build/installers/liferay-workspace/pom.xml
@@ -92,20 +92,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>download-bundle-support</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>${bundle-support-download-base}/${bundle-support-version}/${bundle-support-name}</url>
-                            <outputDirectory>../shared/download/</outputDirectory>
-                            <outputFileName>com.liferay.portal.tools.bundle.support.jar</outputFileName>
-                            <md5>${bundle-support-md5}</md5>
-                            <checkSignature>true</checkSignature>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>download-jpmcli</id>
                         <phase>package</phase>
                         <goals>

--- a/build/installers/pom.xml
+++ b/build/installers/pom.xml
@@ -34,10 +34,6 @@
 
     <properties>
         <install-builder-executable>${install-builder-home}/bin/builder</install-builder-executable>
-        <bundle-support-download-base>https://repository-cdn.liferay.com/nexus/content/groups/public/com/liferay/com.liferay.portal.tools.bundle.support</bundle-support-download-base>
-        <bundle-support-name>com.liferay.portal.tools.bundle.support-3.4.3.jar</bundle-support-name>
-        <bundle-support-version>3.4.3</bundle-support-version>
-        <bundle-support-md5>bdfc6e90fc0e3b1f60fbfb99c3dea084</bundle-support-md5>
         <gw-latest-download-url>https://github.com/david-truong/gw/releases/download/v1.0.1/gw.jar</gw-latest-download-url>
         <gw-latest-md5>488ddaed413c0f7ea67df049175380eb</gw-latest-md5>
         <jpmcli-latest-download-url>https://oss.sonatype.org/content/repositories/snapshots/biz/aQute/bnd/biz.aQute.jpm.run/4.0.0-SNAPSHOT/biz.aQute.jpm.run-4.0.0-20190911.164338-16.jar</jpmcli-latest-download-url>
@@ -67,7 +63,6 @@
                             <directory>shared/download</directory>
                             <includes>
                                 <include>blade.jar</include>
-                                <include>com.liferay.portal.tools.bundle.support.jar</include>
                                 <include>gw.jar</include>
                             </includes>
                         </fileset>


### PR DESCRIPTION
remove buddle support and token from the following installers:
1. liferay workspace
2. liferay worksapce with Studio CE
3. liferay worksapace with Studio Dxp