### PR TITLE
split build and upload repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build repository
+        shell: bash
+        run: |
+          ./mvnw clean package -DskipTests=true
+      - name: Upload repository
         env:
           BINTRAY_USER: ${{ secrets.bintray_usename }}
           BINTRAY_API_KEY: ${{ secrets.bintray_apikey }}
         shell: bash
         run: |
-          ./mvnw clean package -DskipTests=true
+          echo "start uploading ..."
           ./build/com.liferay.ide-repository/deployToBintray.sh ./build/com.liferay.ide-repository/target/repository/ gamerson eclipse liferay-ide update-snapshot


### PR DESCRIPTION
Hi @gamerson , I saw the publish action failed due to timeout after 6 hours. 
This is not a fix, just see if build repo really run ok and upload process is start or not.