### PR TITLE
Questions about IDE-4837(jdk which installed using SDKMan is not detected) 

### DIFF
--- a/build/installers/components/autodetect-java.xml
+++ b/build/installers/components/autodetect-java.xml
@@ -1,4 +1,6 @@
 <autodetectJava>
+    <abortOnError>0</abortOnError>
+    <customErrorMessage>The installer could not find a valid Java(tm) through standard installation paths or environment variables on this machine. Required JDK versions: 1.8 64-Bit JDK and 11 64-Bit JDK. Please click OK and browse a valid java executable file if already have one to continue.</customErrorMessage>
     <promptUser>1</promptUser>
     <validVersionList>
         <validVersion>

--- a/build/installers/components/autodetect-java.xml
+++ b/build/installers/components/autodetect-java.xml
@@ -1,6 +1,6 @@
 <autodetectJava>
     <abortOnError>0</abortOnError>
-    <customErrorMessage>The installer could not find a valid Java(tm) through standard installation paths or environment variables on this machine. Required JDK versions: 1.8 64-Bit JDK and 11 64-Bit JDK. Please click OK and browse a valid java executable file if already have one to continue.</customErrorMessage>
+    <customErrorMessage>The installer could not find a valid Java(tm) through standard installation paths or environment variables on this machine. Required JDK versions: 1.8 64-Bit JDK or 11 64-Bit JDK. Please click OK and browse a valid java executable file to continue.</customErrorMessage>
     <promptUser>1</promptUser>
     <validVersionList>
         <validVersion>

--- a/build/installers/components/run-java-jpm.xml
+++ b/build/installers/components/run-java-jpm.xml
@@ -1,4 +1,4 @@
 <runProgram>
     <program>${java_executable}</program>
-    <programArguments>-jar "${installdir}${platform_path_separator}biz.aQute.jpm.run.jar" -u -b "${userHome}" -h "${jpmSettingPath}" -B "${jpmSystemPath}" init --jvmlocation "${java_executable}"</programArguments>
+    <programArguments> -jar "${installdir}${platform_path_separator}biz.aQute.jpm.run.jar" -u -b "${userHome}" -h "${jpmSettingPath}" -B "${jpmSystemPath}" init --jvmlocation "${java_executable}"</programArguments>
 </runProgram>

--- a/build/installers/components/run-jpm-install-blade.xml
+++ b/build/installers/components/run-jpm-install-blade.xml
@@ -1,4 +1,4 @@
 <runProgram>
-    <program>${jpmFilePath}</program>
-    <programArguments>install -fl --jvmlocation "${java_executable}" "${bladeFilePath}"</programArguments>
+    <program>${java_executable}</program>
+    <programArguments> -jar "${installdir}${platform_path_separator}biz.aQute.jpm.run.jar" install -fl --jvmlocation "${java_executable}" "${bladeFilePath}"</programArguments>
 </runProgram>

--- a/build/installers/components/run-jpm-install-bnd.xml
+++ b/build/installers/components/run-jpm-install-bnd.xml
@@ -1,4 +1,4 @@
 <runProgram>
-    <program>${jpmFilePath}</program>
-    <programArguments>install -fl --jvmlocation "${java_executable}" "${bndFilePath}"</programArguments>
+    <program>${java_executable}</program>
+    <programArguments> -jar "${installdir}${platform_path_separator}biz.aQute.jpm.run.jar" install -fl --jvmlocation "${java_executable}" "${bndFilePath}"</programArguments>
 </runProgram>

--- a/build/installers/components/run-jpm-install-gw.xml
+++ b/build/installers/components/run-jpm-install-gw.xml
@@ -1,4 +1,4 @@
 <runProgram>
-    <program>${jpmFilePath}</program>
-    <programArguments>install -fl --jvmlocation "${java_executable}" "${gwFilePath}"</programArguments>
+    <program>${java_executable}</program>
+    <programArguments> -jar "${installdir}${platform_path_separator}biz.aQute.jpm.run.jar" install -fl --jvmlocation "${java_executable}" "${gwFilePath}"</programArguments>
 </runProgram>

--- a/build/installers/liferay-workspace/liferay-workspace.xml
+++ b/build/installers/liferay-workspace/liferay-workspace.xml
@@ -327,8 +327,8 @@
                     <value>${jpmSystemPath}${platform_path_separator}blade</value>
                 </setInstallerVariable>
                 <runProgram>
-                    <program>${bladeCommondPath}</program>
-                    <programArguments>--base "${lrwsDir}" init -v "${selectbundleversion}"</programArguments>
+                    <program>${java_executable}</program>
+                    <programArguments> -jar "${bladeFilePath}" --base "${lrwsDir}" init -v "${selectbundleversion}"</programArguments>
                 </runProgram>
                 <propertiesFileSet>
                     <file>${lrwsDir}${platform_path_separator}gradle.properties</file>
@@ -505,6 +505,23 @@
     <vendor>Liferay, Inc</vendor>
     <width>600</width>
     <parameterList>
+        <fileParameter>
+            <name>java_executable</name>
+            <title>Select a valid Java(tm) Runtime</title>
+            <description>Java(tm) Runtime</description>
+            <explanation>Please select a valid Java(tm) Runtime</explanation>
+            <value></value>
+            <default></default>
+            <allowEmptyValue>0</allowEmptyValue>
+            <mustBeWritable>0</mustBeWritable>
+            <mustExist>1</mustExist>
+            <width>30</width>
+            <ruleList>
+                <isFalse>
+                    <value>${java_autodetected}</value>
+                </isFalse>
+            </ruleList>
+        </fileParameter>
         <directoryParameter>
             <name>installdir</name>
             <description>Installer.Parameter.installdir.description</description>

--- a/build/installers/liferay-workspace/liferay-workspace.xml
+++ b/build/installers/liferay-workspace/liferay-workspace.xml
@@ -507,7 +507,7 @@
     <parameterList>
         <fileParameter>
             <name>java_executable</name>
-            <title>Select a valid Java(tm) Runtime</title>
+            <title>Select a valid Java(tm) Executable</title>
             <description>Java(tm) Runtime</description>
             <explanation>Please select a valid Java(tm) Runtime</explanation>
             <value></value>


### PR DESCRIPTION
Hi @gamerson ,

I'm not sure if we should support this since from my search,  installbuilder doesn't support JDK which is installed using SDKMan. And I've tried the following to make sure our Workspace Installer did work when changing out codes:

1. If support, my idea is
- If jdk can't be detected, then ask users to browse a valid java executable file to finish installation.
- If jdk is detected, then we keep the old way, I mean not showing the page to browse a java executable file. what do you think? 
![with-valid-jdk](https://user-images.githubusercontent.com/1308942/87665666-dc68c980-c799-11ea-962b-a3fe3480e983.gif)
![without-valid-jdk](https://user-images.githubusercontent.com/1308942/87666013-7761a380-c79a-11ea-8ef1-a60e25768731.gif)


2.one more question: shall we add -vm into studio.ini file since Eclipse doesn't support this kind of jdk installation?Eclipse ticket: https://bugs.eclipse.org/bugs/show_bug.cgi?id=549813

