### PR TITLE
IDE-4837 not display page when jdk detected

### DIFF
--- a/build/installers/liferay-workspace-with-devstudio-ce/liferay-workspace-with-devstudio-ce.xml
+++ b/build/installers/liferay-workspace-with-devstudio-ce/liferay-workspace-with-devstudio-ce.xml
@@ -463,7 +463,6 @@ ${java_executable}
             <parameterList>
                 <fileParameter>
                     <name>java_executable</name>
-                    <title></title>
                     <description>Java(tm) Executable</description>
                     <explanation>Please select a valid Java(tm) Executable</explanation>
                     <value></value>
@@ -472,11 +471,6 @@ ${java_executable}
                     <mustBeWritable>0</mustBeWritable>
                     <mustExist>1</mustExist>
                     <width>30</width>
-                    <ruleList>
-                        <isFalse>
-                            <value>${java_autodetected}</value>
-                        </isFalse>
-                    </ruleList>
                 </fileParameter>
                 <fileParameter>
                     <name>libjli_path</name>
@@ -489,9 +483,6 @@ ${java_executable}
                     <mustExist>1</mustExist>
                     <width>30</width>
                     <ruleList>
-                        <isFalse>
-                            <value>${java_autodetected}</value>
-                        </isFalse>
                         <compareText>
                             <logic>equals</logic>
                             <text>${platform_name}</text>
@@ -500,6 +491,11 @@ ${java_executable}
                     </ruleList>
                 </fileParameter>
             </parameterList>
+            <ruleList>
+                <isFalse>
+                    <value>${java_autodetected}</value>
+                </isFalse>
+            </ruleList>
         </parameterGroup>
         <directoryParameter>
             <name>studiodir</name>

--- a/build/installers/liferay-workspace-with-devstudio-dxp/liferay-workspace-with-devstudio-dxp.xml
+++ b/build/installers/liferay-workspace-with-devstudio-dxp/liferay-workspace-with-devstudio-dxp.xml
@@ -607,7 +607,6 @@ ${java_executable}
             <parameterList>
                 <fileParameter>
                     <name>java_executable</name>
-                    <title></title>
                     <description>Java(tm) Executable</description>
                     <explanation>Please select a valid Java(tm) Executable</explanation>
                     <value></value>
@@ -616,11 +615,6 @@ ${java_executable}
                     <mustBeWritable>0</mustBeWritable>
                     <mustExist>1</mustExist>
                     <width>30</width>
-                    <ruleList>
-                        <isFalse>
-                            <value>${java_autodetected}</value>
-                        </isFalse>
-                    </ruleList>
                 </fileParameter>
                 <fileParameter>
                     <name>libjli_path</name>
@@ -633,9 +627,6 @@ ${java_executable}
                     <mustExist>1</mustExist>
                     <width>30</width>
                     <ruleList>
-                        <isFalse>
-                            <value>${java_autodetected}</value>
-                        </isFalse>
                         <compareText>
                             <logic>equals</logic>
                             <text>${platform_name}</text>
@@ -644,6 +635,11 @@ ${java_executable}
                     </ruleList>
                 </fileParameter>
             </parameterList>
+            <ruleList>
+                <isFalse>
+                    <value>${java_autodetected}</value>
+                </isFalse>
+            </ruleList>
         </parameterGroup>
         <directoryParameter>
             <name>studiodir</name>


### PR DESCRIPTION
Hi @gamerson ,

Since we need to add libjli.dylib into Studio.ini when jdk is not detected, so now on Mac, users will enter both Java Executable and the libjli.dylib path. Is this ok?
![mac](https://user-images.githubusercontent.com/1308942/88013528-34fbe600-cb4f-11ea-8766-a67cbcdbcb5f.png)

On linux, users can only enter the java executable.
![linux](https://user-images.githubusercontent.com/1308942/88013526-32998c00-cb4f-11ea-908c-805d771af8ff.png)

