### PR TITLE
IDE-4837 find libjli.dylib according to java executable path on mac

### DIFF
--- a/build/installers/components/autodetect-java.xml
+++ b/build/installers/components/autodetect-java.xml
@@ -2,6 +2,12 @@
     <abortOnError>0</abortOnError>
     <customErrorMessage>The installer could not find a valid Java(tm) through standard installation paths or environment variables on this machine. Required JDK versions: 1.8 64-Bit JDK or 11 64-Bit JDK. Please click OK and browse a valid java executable file to continue.</customErrorMessage>
     <promptUser>1</promptUser>
+    <ruleList>
+        <platformTest>
+            <negate>1</negate>
+            <type>windows</type>
+        </platformTest>
+    </ruleList>
     <validVersionList>
         <validVersion>
             <bitness>64</bitness>

--- a/build/installers/liferay-workspace-with-devstudio-ce/liferay-workspace-with-devstudio-ce.xml
+++ b/build/installers/liferay-workspace-with-devstudio-ce/liferay-workspace-with-devstudio-ce.xml
@@ -56,6 +56,7 @@
     </componentList>
     <preInstallationActionList>
         <include file="../components/autodetect-java.xml" />
+        <include file="../components/autodetect-java-windows.xml" />
     </preInstallationActionList>
     <postInstallationActionList>
         <if>
@@ -127,6 +128,15 @@
                     <program>chmod</program>
                     <programArguments>+w "${installdir}"/LiferayDeveloperStudio.app/Contents/Eclipse/DeveloperStudio.ini</programArguments>
                 </runProgram>
+                <dirName>
+                    <path>${java_executable}</path>
+                    <variable>find_in_path</variable>
+                </dirName>
+                 <findFile>
+                    <baseDirectory>${find_in_path}/../</baseDirectory>
+                    <pattern>libjli.dylib</pattern>
+                    <variable>libjli_path</variable>
+                </findFile>
                 <addTextToFile>
                     <file>${installdir}/LiferayDeveloperStudio.app/Contents/Eclipse/DeveloperStudio.ini</file>
                     <insertAt>beginning</insertAt>
@@ -454,49 +464,23 @@ ${java_executable}
     <vendor>Liferay, Inc</vendor>
     <width>600</width>
     <parameterList>
-        <parameterGroup>
-            <name>java</name>
+        <fileParameter>
+            <name>java_executable</name>
             <title>Select a valid Java(tm) Executable</title>
-            <explanation></explanation>
+            <description>Java(tm) Executable</description>
+            <explanation>Please select a valid Java(tm) Executable</explanation>
             <value></value>
             <default></default>
-            <parameterList>
-                <fileParameter>
-                    <name>java_executable</name>
-                    <description>Java(tm) Executable</description>
-                    <explanation>Please select a valid Java(tm) Executable</explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>0</allowEmptyValue>
-                    <mustBeWritable>0</mustBeWritable>
-                    <mustExist>1</mustExist>
-                    <width>30</width>
-                </fileParameter>
-                <fileParameter>
-                    <name>libjli_path</name>
-                    <description>Java libjli.dylib library</description>
-                    <explanation>Please select your java libjli.dylib library</explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>0</allowEmptyValue>
-                    <mustBeWritable>0</mustBeWritable>
-                    <mustExist>1</mustExist>
-                    <width>30</width>
-                    <ruleList>
-                        <compareText>
-                            <logic>equals</logic>
-                            <text>${platform_name}</text>
-                            <value>osx</value>
-                        </compareText>
-                    </ruleList>
-                </fileParameter>
-            </parameterList>
+            <allowEmptyValue>0</allowEmptyValue>
+            <mustBeWritable>0</mustBeWritable>
+            <mustExist>1</mustExist>
+            <width>30</width>
             <ruleList>
                 <isFalse>
                     <value>${java_autodetected}</value>
                 </isFalse>
             </ruleList>
-        </parameterGroup>
+        </fileParameter>
         <directoryParameter>
             <name>studiodir</name>
             <description>Installer.Parameter.installdir.description</description>

--- a/build/installers/liferay-workspace-with-devstudio-dxp/liferay-workspace-with-devstudio-dxp.xml
+++ b/build/installers/liferay-workspace-with-devstudio-dxp/liferay-workspace-with-devstudio-dxp.xml
@@ -56,6 +56,7 @@
     </componentList>
     <preInstallationActionList>
         <include file="../components/autodetect-java.xml" />
+        <include file="../components/autodetect-java-windows.xml" />
     </preInstallationActionList>
     <postInstallationActionList>
         <if>
@@ -249,6 +250,15 @@
                     <program>chmod</program>
                     <programArguments>+w "${installdir}"/LiferayDeveloperStudio.app/Contents/Eclipse/DeveloperStudio.ini</programArguments>
                 </runProgram>
+                <dirName>
+                    <path>${java_executable}</path>
+                    <variable>find_in_path</variable>
+                </dirName>
+                 <findFile>
+                    <baseDirectory>${find_in_path}/../</baseDirectory>
+                    <pattern>libjli.dylib</pattern>
+                    <variable>libjli_path</variable>
+                </findFile>
                 <addTextToFile>
                     <file>${installdir}/LiferayDeveloperStudio.app/Contents/Eclipse/DeveloperStudio.ini</file>
                     <insertAt>beginning</insertAt>
@@ -598,49 +608,23 @@ ${java_executable}
     <vendor>Liferay, Inc</vendor>
     <width>600</width>
     <parameterList>
-        <parameterGroup>
-            <name>java</name>
+        <fileParameter>
+            <name>java_executable</name>
             <title>Select a valid Java(tm) Executable</title>
-            <explanation></explanation>
+            <description>Java(tm) Executable</description>
+            <explanation>Please select a valid Java(tm) Executable</explanation>
             <value></value>
             <default></default>
-            <parameterList>
-                <fileParameter>
-                    <name>java_executable</name>
-                    <description>Java(tm) Executable</description>
-                    <explanation>Please select a valid Java(tm) Executable</explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>0</allowEmptyValue>
-                    <mustBeWritable>0</mustBeWritable>
-                    <mustExist>1</mustExist>
-                    <width>30</width>
-                </fileParameter>
-                <fileParameter>
-                    <name>libjli_path</name>
-                    <description>Java libjli.dylib library</description>
-                    <explanation>Please select your java libjli.dylib library</explanation>
-                    <value></value>
-                    <default></default>
-                    <allowEmptyValue>0</allowEmptyValue>
-                    <mustBeWritable>0</mustBeWritable>
-                    <mustExist>1</mustExist>
-                    <width>30</width>
-                    <ruleList>
-                        <compareText>
-                            <logic>equals</logic>
-                            <text>${platform_name}</text>
-                            <value>osx</value>
-                        </compareText>
-                    </ruleList>
-                </fileParameter>
-            </parameterList>
+            <allowEmptyValue>0</allowEmptyValue>
+            <mustBeWritable>0</mustBeWritable>
+            <mustExist>1</mustExist>
+            <width>30</width>
             <ruleList>
                 <isFalse>
                     <value>${java_autodetected}</value>
                 </isFalse>
             </ruleList>
-        </parameterGroup>
+        </fileParameter>
         <directoryParameter>
             <name>studiodir</name>
             <description>Installer.Parameter.installdir.description</description>

--- a/build/installers/liferay-workspace/liferay-workspace.xml
+++ b/build/installers/liferay-workspace/liferay-workspace.xml
@@ -53,6 +53,7 @@
     </componentList>
     <preInstallationActionList>
         <include file="../components/autodetect-java.xml" />
+        <include file="../components/autodetect-java-windows.xml" />
     </preInstallationActionList>
     <postInstallationActionList>
         <createDirectory>


### PR DESCRIPTION
I haven't find a way to detect java executable in InstallBuilder. Now the installers on Mac and Linux will require user to browse a java executable if java is not detected:

![image](https://user-images.githubusercontent.com/1308942/88380357-fd9f6a80-cdd6-11ea-853a-f1287bc314f9.png)