### PR TITLE
IDE-4907 update to eclipse 201906 since 201903 failed to start on mac big sur

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -34,7 +34,7 @@
         <upgrade-plan-content-zip-url>https://dl.bintray.com/gamerson/liferay-ide-files/docs/code-upgrade-docs-20201126.zip</upgrade-plan-content-zip-url>
         <upgrade-plan-content-zip-md5>28c45e79e4a16c163e679b233064db4b</upgrade-plan-content-zip-md5>
         <bndtools-site>https://bndtools.jfrog.io/bndtools/update-latest/libs-release-local/org/bndtools/org.bndtools.p2/5.2.0/org.bndtools.p2-5.2.0.jar!</bndtools-site>
-        <eclipse-site>https://download.eclipse.org/releases/2019-03/201903201000/</eclipse-site>
+        <eclipse-site>https://download.eclipse.org/releases/2019-06/201906191000/</eclipse-site>
         <eclipse-xml-search-site>https://dl.bintray.com/gamerson/eclipse-wtp-xml-search/</eclipse-xml-search-site>
         <gmaven.runtime>1.8</gmaven.runtime>
         <gradle-site>https://download.eclipse.org/buildship/updates/e410/releases/3.x/3.1.2.v20190903-1732</gradle-site>
@@ -47,7 +47,7 @@
         <m2e-archiver-site>https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
         <maven-deps-plugin-site>https://dl.bintray.com/gamerson/eclipse/m2e-maven-dependency-plugin/0.0.4/</maven-deps-plugin-site>
-        <orbit-site>https://download.eclipse.org/tools/orbit/downloads/drops/R20190226160451/repository/</orbit-site>
+        <orbit-site>https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/</orbit-site>
         <osgi-bundles-site>https://dl.bintray.com/gamerson/eclipse/liferay-ide-deps/201904221700/</osgi-bundles-site>
         <sapphire-site>https://download.eclipse.org/sapphire/9.1.1/repository/</sapphire-site>
         <sign-apps>false</sign-apps>


### PR DESCRIPTION
We don't need to update the buildship, m2e, m2e-wtp since the plugins we're using are higher than eclipse 201906.